### PR TITLE
Assets should always be compiled, regardless of `Rails.env`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added <!-- for new features. -->
+
+### Changed <!-- for changes in existing functionality. -->
+
+### Deprecated <!-- for soon-to-be removed features. -->
+
+### Removed <!-- for now removed features. -->
+
+### Fixed <!-- for any bug fixes. -->
+
+## [1.0.1] - 2022-06-03
+
+### Fixed
+
+- Always register demo_mode assets for precompilation, regardless of `Rails.env`.
+
+## [1.0.0] - 2022-05-10
+
+### Added
+
+- Initial release!
+
+[1.0.1]: https://github.com/betterment/demo_mode/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/betterment/demo_mode/releases/tag/v1.0.0

--- a/demo_mode.gemspec
+++ b/demo_mode.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.metadata['rubygems_mfa_required'] = 'true'
 
   s.files = Dir['{app,config,lib}/**/*', "LICENSE", "Rakefile", "README.md"]
-  s.test_files = Dir['spec/**/*']
 
   s.required_ruby_version = ">= 2.7"
 

--- a/demo_mode.gemspec
+++ b/demo_mode.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.description = 'A configurable demo mode for your Rails app. Specify your desired "personas" and DemoMode will handle the rest.'
   s.license = 'MIT'
   s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata['changelog_uri'] = 'https://github.com/Betterment/demo_mode/blob/main/CHANGELOG.md'
 
   s.files = Dir['{app,config,lib}/**/*', "LICENSE", "Rakefile", "README.md"]
 

--- a/lib/demo_mode/engine.rb
+++ b/lib/demo_mode/engine.rb
@@ -23,14 +23,16 @@ module DemoMode
             DemoMode.app_base_controller_name.constantize.include Demoable
           end
         end
-
-        app.config.assets.precompile << 'demo_mode/application.css'
-        app.config.assets.precompile << 'demo_mode/application.js'
-        app.config.assets.precompile << 'demo_mode/icon--user.png'
-        app.config.assets.precompile << 'demo_mode/icon--users.png'
-        app.config.assets.precompile << 'demo_mode/icon--tophat.png'
-        app.config.assets.precompile << 'demo_mode/loader.png'
       end
+    end
+
+    initializer 'demo_mode.assets' do |app|
+      app.config.assets.precompile << 'demo_mode/application.css'
+      app.config.assets.precompile << 'demo_mode/application.js'
+      app.config.assets.precompile << 'demo_mode/icon--user.png'
+      app.config.assets.precompile << 'demo_mode/icon--users.png'
+      app.config.assets.precompile << 'demo_mode/icon--tophat.png'
+      app.config.assets.precompile << 'demo_mode/loader.png'
     end
   end
 end

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,3 +1,3 @@
 module DemoMode
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end


### PR DESCRIPTION
When `assets:precompile` runs with `RAILS_ENV=production`, demo_mode's should still be generated.