### PR TITLE
Fix migration task on newer Rails versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 
 ### Fixed <!-- for any bug fixes. -->
 
+## [1.0.2] - 2022-08-15
+
+### Fixed
+
+- Fixes `demo_mode:install` generator, which was failing to find
+  `demo_mode:install:migrations` task on newer Rails versions.
+
 ## [1.0.1] - 2022-06-03
 
 ### Fixed
@@ -29,5 +36,6 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 
 - Initial release!
 
+[1.0.2]: https://github.com/betterment/demo_mode/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/betterment/demo_mode/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/betterment/demo_mode/releases/tag/v1.0.0

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,3 +1,3 @@
 module DemoMode
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end

--- a/lib/generators/demo_mode/install_generator.rb
+++ b/lib/generators/demo_mode/install_generator.rb
@@ -1,4 +1,5 @@
 require 'rails/generators/base'
+require 'demo_mode/engine'
 
 module DemoMode
   class InstallGenerator < Rails::Generators::Base


### PR DESCRIPTION
/domain @JELaVallee @agirlnamedsophia @medlefsen 
/no-platform

Fixes #4 - I was able to reproduce the issue with a new Rails app. The migration tasks are provided by the Rails Engine, which wasn't getting loaded with newer versions of Rails::Generators::Base.