### PR TITLE
Fix migration generator - rubygems release did not include migrations!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 
 ### Fixed <!-- for any bug fixes. -->
 
+## [1.0.3] - 2022-08-15
+
+### Fixed
+
+- Fixes `demo_mode:install` generator on Rail edge (7.1)
+
 ## [1.0.2] - 2022-08-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 
 ### Fixed
 
-- Fixes `demo_mode:install` generator on Rail edge (7.1)
+- Fixes rubygems release of the gem so that the `db/migrate` folder is actually
+  present.
 
 ## [1.0.2] - 2022-08-15
 

--- a/demo_mode.gemspec
+++ b/demo_mode.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.metadata['rubygems_mfa_required'] = 'true'
   s.metadata['changelog_uri'] = 'https://github.com/Betterment/demo_mode/blob/main/CHANGELOG.md'
 
-  s.files = Dir['{app,config,lib}/**/*', "LICENSE", "Rakefile", "README.md"]
+  s.files = Dir['{app,config,lib,db}/**/*', "LICENSE", "Rakefile", "README.md"]
 
   s.required_ruby_version = ">= 2.7"
 

--- a/lib/demo_mode/engine.rb
+++ b/lib/demo_mode/engine.rb
@@ -26,14 +26,6 @@ module DemoMode
       end
     end
 
-    initializer 'demo_mode.migrations' do |app|
-      unless app.root.to_s.match root.to_s
-        config.paths["db/migrate"].expanded.each do |expanded_path|
-          app.config.paths["db/migrate"] << expanded_path
-        end
-      end
-    end
-
     initializer 'demo_mode.assets' do |app|
       app.config.assets.precompile << 'demo_mode/application.css'
       app.config.assets.precompile << 'demo_mode/application.js'

--- a/lib/demo_mode/engine.rb
+++ b/lib/demo_mode/engine.rb
@@ -26,6 +26,14 @@ module DemoMode
       end
     end
 
+    initializer 'demo_mode.migrations' do |app|
+      unless app.root.to_s.match root.to_s
+        config.paths["db/migrate"].expanded.each do |expanded_path|
+          app.config.paths["db/migrate"] << expanded_path
+        end
+      end
+    end
+
     initializer 'demo_mode.assets' do |app|
       app.config.assets.precompile << 'demo_mode/application.css'
       app.config.assets.precompile << 'demo_mode/application.js'

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,3 +1,3 @@
 module DemoMode
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.0.3'.freeze
 end


### PR DESCRIPTION
/domain @Betterment/demo_mode-core 
/no-platform

Update: This is the actual fix. While #5 blocked the engine's ability to actually load inside of the generator, I still wasn't seeing the migrations applied by the new 1.0.2 -- it turns out it's because they weren't actually being shipped to rubygems.org! 🤦 