### PR TITLE
Replace selenium with cuprite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,11 +22,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: nanasess/setup-chromedriver@v1
-    - run: |
-        export DISPLAY=:99
-        chromedriver --url-base=/wd/hub &
-        sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+    - name: Setup Chrome
+      uses: browser-actions/setup-chrome@latest
+      with:
+        chrome-version: stable
     - uses: ruby/setup-ruby@v1
       env:
         BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ gem 'combustion'
 gem 'factory_bot'
 gem 'net-smtp', require: false # required by combustion on newer rubies
 gem 'rspec-rails', require: false
-gem 'selenium-webdriver'
+gem 'cuprite'
 gem 'uncruft', require: false
 gem 'webrick', require: false

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -2,17 +2,17 @@
 
 source "https://rubygems.org"
 
+gem "sqlite3"
 gem "appraisal", require: false
 gem "betterlint", require: false
 gem "capybara", require: false
 gem "combustion"
 gem "factory_bot"
 gem "net-smtp", require: false
-gem "rails", "~> 6.0.0"
 gem "rspec-rails", require: false
-gem "selenium-webdriver"
-gem "sqlite3"
+gem "cuprite"
 gem "uncruft", require: false
 gem "webrick", require: false
+gem "rails", "~> 6.0.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -2,17 +2,17 @@
 
 source "https://rubygems.org"
 
+gem "sqlite3"
 gem "appraisal", require: false
 gem "betterlint", require: false
 gem "capybara", require: false
 gem "combustion"
 gem "factory_bot"
 gem "net-smtp", require: false
-gem "rails", "~> 6.1.0"
 gem "rspec-rails", require: false
-gem "selenium-webdriver"
-gem "sqlite3"
+gem "cuprite"
 gem "uncruft", require: false
 gem "webrick", require: false
+gem "rails", "~> 6.1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -2,17 +2,17 @@
 
 source "https://rubygems.org"
 
+gem "sqlite3"
 gem "appraisal", require: false
 gem "betterlint", require: false
 gem "capybara", require: false
 gem "combustion"
 gem "factory_bot"
 gem "net-smtp", require: false
-gem "rails", "~> 7.0.0"
 gem "rspec-rails", require: false
-gem "selenium-webdriver"
-gem "sqlite3"
+gem "cuprite"
 gem "uncruft", require: false
 gem "webrick", require: false
+gem "rails", "~> 7.0.0"
 
 gemspec path: "../"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,41 +16,24 @@ Combustion.initialize! :all do
 end
 
 require 'rspec/rails'
+require 'capybara/cuprite'
 
-capybara_driver = ENV.fetch("CAPYBARA_DRIVER", 'selenium_chrome_headless').to_sym
+Capybara.register_driver(:cuprite) do |app|
+  options = {
+    window_size: [1280, 1024],
+    headless: ENV['CAPYBARA_DEBUG'] != '1',
+    js_errors: true,
+  }
 
-case capybara_driver
-  when :selenium_chrome_headless
-    Capybara.register_driver :selenium_chrome_headless do |app|
-      args = %w(headless disable-gpu disable-dev-shm-usage no-sandbox window-size=1280,1024)
-      Capybara::Selenium::Driver.new app,
-                                     browser: :chrome,
-                                     capabilities: [Selenium::WebDriver::Chrome::Options.new(args: args)]
-    end
-  when :selenium_remote_chrome
-    url = ENV.fetch("SELENIUM_REMOTE_URL", "http://localhost:4444/wd/hub")
-
-    Capybara.register_driver :selenium_remote_chrome do |app|
-      Capybara::Selenium::Driver.new(app, browser: :remote, desired_capabilities: :chrome, url: url).tap do |driver|
-        driver.browser.manage.window.size = Selenium::WebDriver::Dimension.new(1280, 1024)
-        driver.browser.file_detector = ->(args) {
-          str = args.first.to_s
-          str if File.exist?(str)
-        }
-      end
-    end
-  else
-    Capybara.register_driver capybara_driver do |app|
-      Capybara::Selenium::Driver.new(app, browser: capybara_driver)
-    end
+  Capybara::Cuprite::Driver.new(app, **options)
 end
 
 Capybara.configure do |config|
   config.match = :one
   config.ignore_hidden_elements = true
   config.visible_text_only = true
-  config.default_driver = capybara_driver
-  config.javascript_driver = capybara_driver
+  config.default_driver = :cuprite
+  config.javascript_driver = :cuprite
 
   config.default_max_wait_time = ENV.fetch('CAPYBARA_WAIT_TIME', 2).to_i
   config.server = :webrick
@@ -65,7 +48,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.before(:each, type: :system) do
-    driven_by capybara_driver
+    driven_by :cuprite
   end
 
   config.around(:each, :demo_mode_enabled) do |example|


### PR DESCRIPTION
Cuprite is much simpler to setup and use. It also ensures that CI is identical to the local test environment.

Also, by enabling `js_errors: true`, we can see JavaScript errors that are thrown.