### PR TITLE
Add cli-ui gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    demo_mode (1.2.0)
+    demo_mode (1.2.1)
+      cli-ui
       rails (>= 6.1)
       sprockets-rails
       typedjs-rails
@@ -108,6 +109,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cli-ui (2.2.3)
     combustion (1.3.7)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
@@ -152,7 +154,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.23.1)
     mutex_m (0.2.0)
-    net-imap (0.4.10)
+    net-imap (0.4.12)
       date
       net-protocol
     net-pop (0.1.2)
@@ -161,7 +163,9 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
-    nio4r (2.7.0)
+    nio4r (2.7.3)
+    nokogiri (1.16.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
@@ -271,10 +275,11 @@ GEM
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
+    sprockets-rails (3.5.1)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    sqlite3 (1.7.0-arm64-darwin)
     sqlite3 (1.7.0-x86_64-darwin)
     sqlite3 (1.7.0-x86_64-linux)
     stringio (3.1.0)
@@ -296,6 +301,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-22
   x86_64-linux
 

--- a/demo_mode.gemspec
+++ b/demo_mode.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.0"
 
+  s.add_dependency 'cli-ui'
   s.add_dependency 'rails', '>= 6.1'
   s.add_dependency 'sprockets-rails'
   s.add_dependency 'typedjs-rails'

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    demo_mode (1.2.0)
+    demo_mode (1.2.1)
+      cli-ui
       rails (>= 6.1)
       sprockets-rails
       typedjs-rails
@@ -91,6 +92,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cli-ui (2.2.3)
     combustion (1.3.7)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
@@ -139,6 +141,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.15.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.5-x86_64-linux)
@@ -240,6 +244,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.7.0-arm64-darwin)
     sqlite3 (1.7.0-x86_64-darwin)
     sqlite3 (1.7.0-x86_64-linux)
     thor (1.3.0)
@@ -260,6 +265,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-22
   x86_64-linux
 

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    demo_mode (1.2.0)
+    demo_mode (1.2.1)
+      cli-ui
       rails (>= 6.1)
       sprockets-rails
       typedjs-rails
@@ -97,6 +98,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cli-ui (2.2.3)
     combustion (1.3.7)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
@@ -145,6 +147,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.15.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.5-x86_64-linux)
@@ -242,10 +246,11 @@ GEM
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
+    sprockets-rails (3.5.1)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    sqlite3 (1.7.0-arm64-darwin)
     sqlite3 (1.7.0-x86_64-darwin)
     sqlite3 (1.7.0-x86_64-linux)
     thor (1.3.0)
@@ -266,6 +271,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-22
   x86_64-linux
 

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
The [Developer CLI](https://github.com/Betterment/demo_mode?tab=readme-ov-file#developer-cli) uses [cli-ui](https://github.com/Shopify/cli-ui), but doesn't include it as a dependency, thus requiring the vendoring app to depend on that gem directly in order to leverage the CLI.

Running `bundle exec rails persona:create` from a project that doesn't depend on `cli-ui` currently produces the following error:

```
NameError: uninitialized constant DemoMode::Clis::MultiWordSearchPatch::CLI (NameError)

      CLI::UI::Prompt.const_get(:InteractiveOptions)
             ^^^^^^^^
```