### PR TITLE
Add require for cli/ui

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (1.2.1)
+    demo_mode (1.2.2)
       cli-ui
       rails (>= 6.1)
       sprockets-rails

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (1.2.1)
+    demo_mode (1.2.2)
       cli-ui
       rails (>= 6.1)
       sprockets-rails

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (1.2.1)
+    demo_mode (1.2.2)
       cli-ui
       rails (>= 6.1)
       sprockets-rails

--- a/lib/demo_mode/cli.rb
+++ b/lib/demo_mode/cli.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'cli/ui'
 require 'demo_mode/clis/multi_word_search_patch'
 
 # rubocop:disable Rails/Output, Rails/Exit

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end


### PR DESCRIPTION
This is related to https://github.com/Betterment/demo_mode/pull/23. I was too hasty and forgot to actually `require 'cli/ui'` as outlined in the [cli-ui](https://github.com/Shopify/cli-ui?tab=readme-ov-file#installation) installation instructions.

I tested this in a project using demo_mode by pointing it at this branch of the gem locally and this resolved the same issue mentioned in https://github.com/Betterment/demo_mode/pull/23 (which that PR didn't resolve on its own).