### PR TITLE
feat(): introducing option param to sessions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (1.4.0)
+    demo_mode (1.4.1)
       cli-ui
       rails (>= 6.1)
       sprockets-rails

--- a/app/controllers/demo_mode/sessions_controller.rb
+++ b/app/controllers/demo_mode/sessions_controller.rb
@@ -25,7 +25,7 @@ module DemoMode
 
     def create
       @session = Session.new(create_params)
-      @session.save_and_generate_account_later!(option_params)
+      @session.save_and_generate_account_later!(options_params)
       session[:demo_session] = { 'id' => @session.id, 'last_request_at' => Time.zone.now }
       respond_to do |f|
         f.html { redirect_to @session }
@@ -78,8 +78,8 @@ module DemoMode
       params.require(:session).permit(:persona_name, :variant)
     end
 
-    def option_params
-      params.fetch(:option, {}).permit!
+    def options_params
+      params.fetch(:options, {}).permit!
     end
   end
 end

--- a/app/controllers/demo_mode/sessions_controller.rb
+++ b/app/controllers/demo_mode/sessions_controller.rb
@@ -25,7 +25,7 @@ module DemoMode
 
     def create
       @session = Session.new(create_params)
-      @session.save_and_generate_account_later!
+      @session.save_and_generate_account_later!(option_params)
       session[:demo_session] = { 'id' => @session.id, 'last_request_at' => Time.zone.now }
       respond_to do |f|
         f.html { redirect_to @session }
@@ -76,6 +76,10 @@ module DemoMode
 
     def create_params
       params.require(:session).permit(:persona_name, :variant)
+    end
+
+    def option_params
+      params.fetch(:option, {}).permit!
     end
   end
 end

--- a/app/controllers/demo_mode/sessions_controller.rb
+++ b/app/controllers/demo_mode/sessions_controller.rb
@@ -25,7 +25,7 @@ module DemoMode
 
     def create
       @session = Session.new(create_params)
-      @session.save_and_generate_account_later!(options_params)
+      @session.save_and_generate_account_later!(**options_params.to_unsafe_h.deep_symbolize_keys)
       session[:demo_session] = { 'id' => @session.id, 'last_request_at' => Time.zone.now }
       respond_to do |f|
         f.html { redirect_to @session }

--- a/app/jobs/demo_mode/account_generation_job.rb
+++ b/app/jobs/demo_mode/account_generation_job.rb
@@ -2,12 +2,12 @@
 
 module DemoMode
   class AccountGenerationJob < DemoMode.base_job_name.constantize
-    def perform(session, option = nil)
+    def perform(session, options = nil)
       session.with_lock do
         persona = session.persona
         raise "Unknown persona: #{session.persona_name}" if persona.blank?
 
-        signinable = persona.generate!(variant: session.variant, password: session.signinable_password, option: option)
+        signinable = persona.generate!(variant: session.variant, password: session.signinable_password, options: options)
         session.update!(signinable: signinable)
       end
       raise "Failed to create signinable persona!" if session.signinable.blank?

--- a/app/jobs/demo_mode/account_generation_job.rb
+++ b/app/jobs/demo_mode/account_generation_job.rb
@@ -2,7 +2,7 @@
 
 module DemoMode
   class AccountGenerationJob < DemoMode.base_job_name.constantize
-    def perform(session, options = nil)
+    def perform(session, **options)
       session.with_lock do
         persona = session.persona
         raise "Unknown persona: #{session.persona_name}" if persona.blank?

--- a/app/jobs/demo_mode/account_generation_job.rb
+++ b/app/jobs/demo_mode/account_generation_job.rb
@@ -2,12 +2,12 @@
 
 module DemoMode
   class AccountGenerationJob < DemoMode.base_job_name.constantize
-    def perform(session)
+    def perform(session, option = nil)
       session.with_lock do
         persona = session.persona
         raise "Unknown persona: #{session.persona_name}" if persona.blank?
 
-        signinable = persona.generate!(variant: session.variant, password: session.signinable_password)
+        signinable = persona.generate!(variant: session.variant, password: session.signinable_password, option: option)
         session.update!(signinable: signinable)
       end
       raise "Failed to create signinable persona!" if session.signinable.blank?

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -25,17 +25,17 @@ module DemoMode
       DemoMode.personas.find { |p| p.name.to_s == persona_name.to_s }
     end
 
-    def save_and_generate_account!(options = nil)
+    def save_and_generate_account!(**options)
       transaction do
         save!
-        AccountGenerationJob.perform_now(self, options)
+        AccountGenerationJob.perform_now(self, **options)
       end
     end
 
-    def save_and_generate_account_later!(options = nil)
+    def save_and_generate_account_later!(**options)
       transaction do
         save!
-        AccountGenerationJob.perform_later(self, options)
+        AccountGenerationJob.perform_later(self, **options)
       end
     end
 

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -25,17 +25,17 @@ module DemoMode
       DemoMode.personas.find { |p| p.name.to_s == persona_name.to_s }
     end
 
-    def save_and_generate_account!(option = nil)
+    def save_and_generate_account!(options = nil)
       transaction do
         save!
-        AccountGenerationJob.perform_now(self, option)
+        AccountGenerationJob.perform_now(self, options)
       end
     end
 
-    def save_and_generate_account_later!(option = nil)
+    def save_and_generate_account_later!(options = nil)
       transaction do
         save!
-        AccountGenerationJob.perform_later(self, option)
+        AccountGenerationJob.perform_later(self, options)
       end
     end
 

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -25,17 +25,17 @@ module DemoMode
       DemoMode.personas.find { |p| p.name.to_s == persona_name.to_s }
     end
 
-    def save_and_generate_account!
+    def save_and_generate_account!(option = nil)
       transaction do
         save!
-        AccountGenerationJob.perform_now(self)
+        AccountGenerationJob.perform_now(self, option)
       end
     end
 
-    def save_and_generate_account_later!
+    def save_and_generate_account_later!(option = nil)
       transaction do
         save!
-        AccountGenerationJob.perform_later(self)
+        AccountGenerationJob.perform_later(self, option)
       end
     end
 

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (1.4.0)
+    demo_mode (1.4.1)
       cli-ui
       rails (>= 6.1)
       sprockets-rails

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (1.4.0)
+    demo_mode (1.4.1)
       cli-ui
       rails (>= 6.1)
       sprockets-rails

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -54,11 +54,11 @@ module DemoMode
       @variants ||= {}.with_indifferent_access
     end
 
-    def generate!(variant: :default, password: nil)
+    def generate!(variant: :default, password: nil, option: nil)
       variant = variants[variant]
       CleverSequence.reset! if defined?(CleverSequence)
       DemoMode.current_password = password if password
-      DemoMode.around_persona_generation.call(variant.signinable_generator)
+      DemoMode.around_persona_generation.call(variant.signinable_generator, option)
     ensure
       DemoMode.current_password = nil
     end

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -54,11 +54,11 @@ module DemoMode
       @variants ||= {}.with_indifferent_access
     end
 
-    def generate!(variant: :default, password: nil, options: nil)
+    def generate!(variant: :default, password: nil, options: {})
       variant = variants[variant]
       CleverSequence.reset! if defined?(CleverSequence)
       DemoMode.current_password = password if password
-      DemoMode.around_persona_generation.call(variant.signinable_generator, options)
+      DemoMode.around_persona_generation.call(variant.signinable_generator, **options)
     ensure
       DemoMode.current_password = nil
     end

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -54,11 +54,11 @@ module DemoMode
       @variants ||= {}.with_indifferent_access
     end
 
-    def generate!(variant: :default, password: nil, option: nil)
+    def generate!(variant: :default, password: nil, options: nil)
       variant = variants[variant]
       CleverSequence.reset! if defined?(CleverSequence)
       DemoMode.current_password = password if password
-      DemoMode.around_persona_generation.call(variant.signinable_generator, option)
+      DemoMode.around_persona_generation.call(variant.signinable_generator, options)
     ensure
       DemoMode.current_password = nil
     end

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end

--- a/spec/requests/demo_mode/sessions_spec.rb
+++ b/spec/requests/demo_mode/sessions_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe DemoMode::SessionsController do # rubocop:disable RSpec/FilePath
 
       context 'with option' do
         before do
-          DemoMode.configure do  
-            around_persona_generation do |generator, options|
+          DemoMode.configure do
+            around_persona_generation do |_, options|
               if options.present? && options[:example_custom_option].present?
                 DummyUser.create!(name: options[:example_custom_option][:name])
               end
@@ -87,7 +87,7 @@ RSpec.describe DemoMode::SessionsController do # rubocop:disable RSpec/FilePath
           end
         end
 
-        let (:options) { { example_custom_option: { name: 'Tester' } } }
+        let(:options) { { example_custom_option: { name: 'Tester' } } }
 
         it 'creates a session and returns processing json saving the option on the created session' do
           post '/ohno/sessions', params: {

--- a/spec/requests/demo_mode/sessions_spec.rb
+++ b/spec/requests/demo_mode/sessions_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DemoMode::SessionsController do # rubocop:disable RSpec/FilePath
         it 'creates a session and redirects to the session' do
           post '/ohno/sessions', params: {
             session: { persona_name: 'the_everyperson', variant: 'alternate bruce' },
-            option: { example_custom_option: 'this is an example' },
+            options: { example_custom_option: 'this is an example' },
           }
 
           last_session = DemoMode::Session.last
@@ -45,7 +45,7 @@ RSpec.describe DemoMode::SessionsController do # rubocop:disable RSpec/FilePath
         it 'creates a session and returns processing json' do
           post '/ohno/sessions', params: {
             session: { persona_name: 'the_everyperson' },
-            option: { example_custom_option: 'this is an example' },
+            options: { example_custom_option: 'this is an example' },
           }.to_json, headers: request_headers
 
           last_session = DemoMode::Session.last
@@ -64,7 +64,7 @@ RSpec.describe DemoMode::SessionsController do # rubocop:disable RSpec/FilePath
               persona_name: 'the_everyperson',
               variant: 'alternate bruce',
             },
-            option: { example_custom_option: 'this is an example' },
+            options: { example_custom_option: 'this is an example' },
           }.to_json, headers: request_headers
 
           last_session = DemoMode::Session.last

--- a/spec/requests/demo_mode/sessions_spec.rb
+++ b/spec/requests/demo_mode/sessions_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe DemoMode::SessionsController do # rubocop:disable RSpec/FilePath
         it 'creates a session and redirects to the session' do
           post '/ohno/sessions', params: {
             session: { persona_name: 'the_everyperson', variant: 'alternate bruce' },
+            option: { example_custom_option: 'this is an example' },
           }
 
           last_session = DemoMode::Session.last
@@ -44,6 +45,7 @@ RSpec.describe DemoMode::SessionsController do # rubocop:disable RSpec/FilePath
         it 'creates a session and returns processing json' do
           post '/ohno/sessions', params: {
             session: { persona_name: 'the_everyperson' },
+            option: { example_custom_option: 'this is an example' },
           }.to_json, headers: request_headers
 
           last_session = DemoMode::Session.last
@@ -62,6 +64,7 @@ RSpec.describe DemoMode::SessionsController do # rubocop:disable RSpec/FilePath
               persona_name: 'the_everyperson',
               variant: 'alternate bruce',
             },
+            option: { example_custom_option: 'this is an example' },
           }.to_json, headers: request_headers
 
           last_session = DemoMode::Session.last


### PR DESCRIPTION
This pull request introduces support for passing additional options when creating demo mode sessions. The changes involve updates to controllers, models, jobs, and tests to handle the new `options` parameter.

Key changes include:

### Controllers:

* [`app/controllers/demo_mode/sessions_controller.rb`](diffhunk://#diff-7061eec77ccb3a1217893822312e65f7c45fde9996183101f9abfb0f3e7cc4a4L28-R28): Updated the `create` method to pass `options_params` to `save_and_generate_account_later!` and added the `options_params` method to permit all options parameters. [[1]](diffhunk://#diff-7061eec77ccb3a1217893822312e65f7c45fde9996183101f9abfb0f3e7cc4a4L28-R28) [[2]](diffhunk://#diff-7061eec77ccb3a1217893822312e65f7c45fde9996183101f9abfb0f3e7cc4a4R80-R83)

### Models:

* [`app/models/demo_mode/session.rb`](diffhunk://#diff-0f5153bb33011b630b517794bf263bb46b0117d52ced272798cd460e2cf0714cL28-R38): Modified `save_and_generate_account!` and `save_and_generate_account_later!` to accept and pass `options` to the `AccountGenerationJob`.

### Jobs:

* [`app/jobs/demo_mode/account_generation_job.rb`](diffhunk://#diff-a49d57b06c5135304ed8fdd1be432a64e25761e477a88123ab4c554a6e6356efL5-R10): Updated the `perform` method to accept and use `options` when generating a persona.

### Library:

* [`lib/demo_mode/persona.rb`](diffhunk://#diff-dcad6a8f33f3bdcc74ba2aecae17e21b00aa0ed4ce85c7fa406513ea01f828d9L57-R61): Enhanced the `generate!` method to accept and use `options` during persona generation.

### Tests:

* [`spec/requests/demo_mode/sessions_spec.rb`](diffhunk://#diff-c5cfc8d30c2f238c6b2a4add285f4fb65c8cad4e12449097d780f7d1c5c3c4b1R30): Added tests to ensure sessions can be created with options and that these options are correctly processed and saved. [[1]](diffhunk://#diff-c5cfc8d30c2f238c6b2a4add285f4fb65c8cad4e12449097d780f7d1c5c3c4b1R30) [[2]](diffhunk://#diff-c5cfc8d30c2f238c6b2a4add285f4fb65c8cad4e12449097d780f7d1c5c3c4b1R48) [[3]](diffhunk://#diff-c5cfc8d30c2f238c6b2a4add285f4fb65c8cad4e12449097d780f7d1c5c3c4b1R67) [[4]](diffhunk://#diff-c5cfc8d30c2f238c6b2a4add285f4fb65c8cad4e12449097d780f7d1c5c3c4b1R78-R107)

Additionally, the version number was incremented to `1.4.1` in `lib/demo_mode/version.rb`.