### PR TITLE
Include the public directory in the gemspec's declared files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (2.0.0)
+    demo_mode (2.0.1)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/demo_mode.gemspec
+++ b/demo_mode.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.metadata['rubygems_mfa_required'] = 'true'
   s.metadata['changelog_uri'] = 'https://github.com/Betterment/demo_mode/blob/main/CHANGELOG.md'
 
-  s.files = Dir['{app,config,lib,db}/**/*', "LICENSE", "Rakefile", "README.md"]
+  s.files = Dir['{app,config,lib,db,public}/**/*', "LICENSE", "Rakefile", "README.md"]
 
   s.required_ruby_version = ">= 3.0"
 

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.0.0)
+    demo_mode (2.0.1)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.0.0)
+    demo_mode (2.0.1)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.0.0)
+    demo_mode (2.0.1)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.0.0)
+    demo_mode (2.0.1)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.0.0)
+    demo_mode (2.0.1)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end


### PR DESCRIPTION
The v2.0.0 release didn't include the `public/` directory. This PR fixes that.