### PR TITLE
Restore the ability to customize styles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (2.0.1)
+    demo_mode (2.1.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ generation), and the default persona icon:
 
 ```ruby
 DemoMode.configure do
+  head { stylesheet_link_tag('my_styles') }
   logo { image_tag('my-company-logo.svg') }
   loader { render partial: 'shared/loading_spinner' }
 
@@ -311,16 +312,9 @@ DemoMode.add_persona do
 end
 ```
 
-To customize or override the CSS entirely, create your own application.css
-file at `app/assets/stylesheets/demo_mode/application.css`:
+The styles use these CSS variables, which you can override.
 
 ```css
-/*
- *= require demo_mode/normalize
- *= require demo_mode/default
- *= require_self
- */
-
 /* Use CSS variables to override the default font and colors: */
 :root {
   --font-family: Papyrus, fantasy; 

--- a/app/views/layouts/demo_mode/application.html.erb
+++ b/app/views/layouts/demo_mode/application.html.erb
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="/assets/demo_mode/demo_mode.css?v=<%= DemoMode::VERSION %>">
   <script src="/assets/demo_mode/vendor/typed-v2.1.0.js"></script>
   <script src="/assets/demo_mode/demo_mode.js?v=<%= DemoMode::VERSION %>"></script>
+  <%= instance_eval(&DemoMode.head) %>
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width, initial-scale=1.0 maximum-scale=1.0, user-scalable=0">
 </head>

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.0.1)
+    demo_mode (2.1.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.0.1)
+    demo_mode (2.1.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.0.1)
+    demo_mode (2.1.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.0.1)
+    demo_mode (2.1.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.0.1)
+    demo_mode (2.1.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/lib/demo_mode/config.rb
+++ b/lib/demo_mode/config.rb
@@ -14,6 +14,7 @@ module DemoMode
     configurable_value(:personas_path) { 'config/personas' }
     configurable_value(:session_timeout) { 30.minutes }
     configurable_boolean(:display_credentials)
+    configurations << :head
     configurations << :logo
     configurations << :loader
     configurations << :icon
@@ -25,6 +26,14 @@ module DemoMode
 
     def self.app_name
       Rails.application.class.module_parent.name
+    end
+
+    def head(&block)
+      if block
+        @head = block if block
+      else
+        @head ||= ->(_) {}
+      end
     end
 
     def logo(&block)

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '2.0.1'
+  VERSION = '2.1.0'
 end

--- a/spec/demo_mode_spec.rb
+++ b/spec/demo_mode_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe DemoMode do
         logo { '<marquee>The Logo</marquee>' }
         icon { ':-)' }
         loader { image_tag('loading-for-real.gif', skip_pipeline: true) }
+        head { content_tag(:style, nil, id: 'custom-styles') }
 
         persona :my_persona do
           icon :tophat
@@ -123,6 +124,7 @@ RSpec.describe DemoMode do
         end
       end
 
+      expect(render_value(described_class.head)).to eq '<style id="custom-styles"></style>'
       expect(render_value(described_class.logo)).to eq '<marquee>The Logo</marquee>'
       expect(render_value(described_class.loader)).to match %r{img src="/images/loading-for-real.gif"}
       expect(described_class.personas.count).to eq 3

--- a/spec/requests/demo_mode/sessions_spec.rb
+++ b/spec/requests/demo_mode/sessions_spec.rb
@@ -138,6 +138,15 @@ RSpec.describe DemoMode::SessionsController do # rubocop:disable RSpec/FilePath
       end
     end
 
+    describe 'GET /sessions/new' do
+      it 'renders head tags' do
+        DemoMode.head { content_tag(:style, nil, id: 'custom-styles') }
+
+        get '/ohno/sessions/new'
+        expect(response.body).to include('<style id="custom-styles"></style>')
+      end
+    end
+
     describe 'GET /sessions/new.json' do
       it 'returns a list of personas in json' do
         get '/ohno/sessions/new', params: {}, headers: request_headers


### PR DESCRIPTION
In v1, the default styles could be overridden using Rails template overrides. Now that we're not using sprockets, that's just not possible anymore.

As an alternative, this PR allows custom stylesheets to be injected into the `<head>` of the document.