### PR TITLE
Fix CLI::UI compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,7 @@ GEM
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     securerandom (0.3.2)
+    sorbet-runtime (0.5.11820)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -285,6 +286,7 @@ DEPENDENCIES
   nokogiri (~> 1.17.2)
   rspec-rails
   securerandom (~> 0.3.2)
+  sorbet-runtime
   sprockets-rails
   sqlite3
   webrick

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)
       activesupport (>= 6.1, < 8.1)
-      cli-ui (~> 1.3.0)
+      cli-ui (~> 2.3)
       railties (>= 6.1, < 8.1)
 
 GEM
@@ -84,7 +84,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cli-ui (1.3.0)
+    cli-ui (2.3.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (2.1.0)
+    demo_mode (2.1.1)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/demo_mode.gemspec
+++ b/demo_mode.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activejob', rails_constraints
   s.add_dependency 'activerecord', rails_constraints
   s.add_dependency 'activesupport', rails_constraints
-  s.add_dependency 'cli-ui', '~> 1.3.0'
+  s.add_dependency 'cli-ui', '~> 2.3'
   s.add_dependency 'railties', rails_constraints
 
   s.add_development_dependency 'actionmailer', rails_constraints

--- a/demo_mode.gemspec
+++ b/demo_mode.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'net-smtp'
   s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'sorbet-runtime'
   s.add_development_dependency 'sprockets-rails'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'webrick'

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)
       activesupport (>= 6.1, < 8.1)
-      cli-ui (~> 1.3.0)
+      cli-ui (~> 2.3)
       railties (>= 6.1, < 8.1)
 
 GEM
@@ -71,7 +71,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cli-ui (1.3.0)
+    cli-ui (2.3.0)
     concurrent-ruby (1.3.4)
     crass (1.0.6)
     cuprite (0.15.1)

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.1.0)
+    demo_mode (2.1.1)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)
@@ -199,6 +199,7 @@ GEM
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     securerandom (0.3.2)
+    sorbet-runtime (0.5.11820)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -247,6 +248,7 @@ DEPENDENCIES
   railties (~> 6.1.0)
   rspec-rails
   securerandom (~> 0.3.2)
+  sorbet-runtime
   sprockets-rails
   sqlite3 (~> 1.4)
   webrick

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)
       activesupport (>= 6.1, < 8.1)
-      cli-ui (~> 1.3.0)
+      cli-ui (~> 2.3)
       railties (>= 6.1, < 8.1)
 
 GEM
@@ -73,7 +73,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cli-ui (1.3.0)
+    cli-ui (2.3.0)
     concurrent-ruby (1.3.4)
     crass (1.0.6)
     cuprite (0.15.1)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.1.0)
+    demo_mode (2.1.1)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)
@@ -202,6 +202,7 @@ GEM
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     securerandom (0.3.2)
+    sorbet-runtime (0.5.11820)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -250,6 +251,7 @@ DEPENDENCIES
   railties (~> 7.0.0)
   rspec-rails
   securerandom (~> 0.3.2)
+  sorbet-runtime
   sprockets-rails
   sqlite3 (~> 1.4)
   webrick

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)
       activesupport (>= 6.1, < 8.1)
-      cli-ui (~> 1.3.0)
+      cli-ui (~> 2.3)
       railties (>= 6.1, < 8.1)
 
 GEM
@@ -87,7 +87,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cli-ui (1.3.0)
+    cli-ui (2.3.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.1.0)
+    demo_mode (2.1.1)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)
@@ -240,6 +240,7 @@ GEM
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     securerandom (0.3.2)
+    sorbet-runtime (0.5.11820)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -288,6 +289,7 @@ DEPENDENCIES
   railties (~> 7.1.0)
   rspec-rails
   securerandom (~> 0.3.2)
+  sorbet-runtime
   sprockets-rails
   sqlite3 (~> 1.7.3)
   webrick

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)
       activesupport (>= 6.1, < 8.1)
-      cli-ui (~> 1.3.0)
+      cli-ui (~> 2.3)
       railties (>= 6.1, < 8.1)
 
 GEM
@@ -84,7 +84,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cli-ui (1.3.0)
+    cli-ui (2.3.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.1.0)
+    demo_mode (2.1.1)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)
@@ -236,6 +236,7 @@ GEM
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     securerandom (0.3.2)
+    sorbet-runtime (0.5.11820)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -285,6 +286,7 @@ DEPENDENCIES
   railties (~> 7.2.0)
   rspec-rails
   securerandom (~> 0.3.2)
+  sorbet-runtime
   sprockets-rails
   sqlite3 (~> 1.7.3)
   webrick

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.1.0)
+    demo_mode (2.1.1)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)
@@ -236,6 +236,7 @@ GEM
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     securerandom (0.3.2)
+    sorbet-runtime (0.5.11820)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -286,6 +287,7 @@ DEPENDENCIES
   railties (~> 8.0.0)
   rspec-rails
   securerandom (~> 0.3.2)
+  sorbet-runtime
   sprockets-rails
   sqlite3 (>= 2.1)
   webrick

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -6,7 +6,7 @@ PATH
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)
       activesupport (>= 6.1, < 8.1)
-      cli-ui (~> 1.3.0)
+      cli-ui (~> 2.3)
       railties (>= 6.1, < 8.1)
 
 GEM
@@ -84,7 +84,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cli-ui (1.3.0)
+    cli-ui (2.3.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/spec/demo_mode/cli_spec.rb
+++ b/spec/demo_mode/cli_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'sorbet-runtime'
 require 'demo_mode/cli'
 
 RSpec.describe DemoMode::Cli do


### PR DESCRIPTION
The `persona:create` task is failing on newer versions of `CLI::UI`. It seems like we're using prompts in a way that `CLI::UI` wasn't designed to be used.

CLI::UI expects:
* [All options to be strings](https://github.com/Shopify/cli-ui/blob/v2.3.0/lib/cli/ui/prompt.rb#L108)
* [All handlers to return strings](https://github.com/Shopify/cli-ui/blob/v2.3.0/lib/cli/ui/prompt/options_handler.rb#L21-L24)

