### PR TITLE
Accept callables as stylesheets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (2.1.1)
+    demo_mode (2.2.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/app/views/layouts/demo_mode/application.html.erb
+++ b/app/views/layouts/demo_mode/application.html.erb
@@ -7,7 +7,11 @@
   <%= favicon_link_tag '/favicon.ico' %>
 
   <% DemoMode.stylesheets.each do |stylesheet| %>
-    <%= stylesheet_link_tag(stylesheet, media: 'all') %>
+    <% if stylesheet.respond_to?(:call) %>
+      <%= stylesheet_link_tag(instance_eval(&stylesheet), media: 'all') %>
+    <% else %>
+      <%= stylesheet_link_tag(stylesheet, media: 'all') %>
+    <% end %>
   <% end %>
 
   <script src="/assets/demo_mode/vendor/typed-v2.1.0.js"></script>

--- a/app/views/layouts/demo_mode/application.html.erb
+++ b/app/views/layouts/demo_mode/application.html.erb
@@ -8,7 +8,7 @@
 
   <% DemoMode.stylesheets.each do |stylesheet| %>
     <% if stylesheet.respond_to?(:call) %>
-      <%= stylesheet_link_tag(instance_eval(&stylesheet), media: 'all') %>
+      <%= stylesheet_link_tag(instance_exec(&stylesheet), media: 'all') %>
     <% else %>
       <%= stylesheet_link_tag(stylesheet, media: 'all') %>
     <% end %>

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.1.1)
+    demo_mode (2.2.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.1.1)
+    demo_mode (2.2.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.1.1)
+    demo_mode (2.2.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.1.1)
+    demo_mode (2.2.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (2.1.1)
+    demo_mode (2.2.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '2.1.1'
+  VERSION = '2.2.0'
 end

--- a/spec/requests/demo_mode/sessions_spec.rb
+++ b/spec/requests/demo_mode/sessions_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe DemoMode::SessionsController do # rubocop:disable RSpec/FilePath
       end
 
       it 'renders a custom stylesheet provided as a callable' do
-        DemoMode.stylesheets << ->(_) { asset_path('/custom-styles.css') }
+        DemoMode.stylesheets << -> { asset_path('/custom-styles.css') }
 
         get '/ohno/sessions/new'
         expect(response.body).to match(%r{<link .+ href="/custom-styles.css"})

--- a/spec/requests/demo_mode/sessions_spec.rb
+++ b/spec/requests/demo_mode/sessions_spec.rb
@@ -139,8 +139,15 @@ RSpec.describe DemoMode::SessionsController do # rubocop:disable RSpec/FilePath
     end
 
     describe 'GET /sessions/new' do
-      it 'renders head tags' do
+      it 'renders a custom stylesheet' do
         DemoMode.stylesheets << '/custom-styles.css'
+
+        get '/ohno/sessions/new'
+        expect(response.body).to match(%r{<link .+ href="/custom-styles.css"})
+      end
+
+      it 'renders a custom stylesheet provided as a callable' do
+        DemoMode.stylesheets << ->(_) { asset_path('/custom-styles.css') }
 
         get '/ohno/sessions/new'
         expect(response.body).to match(%r{<link .+ href="/custom-styles.css"})


### PR DESCRIPTION
This PR allows you to add callables to the list of stylesheets:

```ruby
stylesheets.unshift ->(_) { asset_path('whatever'} }
```