### PR TITLE
Accept a custom path to override begin demo redirect_to

### DIFF
--- a/app/controllers/demo_mode/sessions_controller.rb
+++ b/app/controllers/demo_mode/sessions_controller.rb
@@ -45,7 +45,7 @@ module DemoMode
     end
 
     def begin_demo!
-      instance_eval(&@session.begin_demo.call(**query_params.to_unsafe_h.deep_symbolize_keys))
+      instance_eval(&@session.begin_demo.call(redirect_to: redirect_params))
     end
 
     def render_signinable_json
@@ -80,6 +80,10 @@ module DemoMode
 
     def options_params
       params.fetch(:options, {}).permit!
+    end
+
+    def redirect_params
+      Helper::PathParser.parse(query_params[:redirect_to])
     end
 
     def query_params

--- a/app/controllers/demo_mode/sessions_controller.rb
+++ b/app/controllers/demo_mode/sessions_controller.rb
@@ -45,7 +45,7 @@ module DemoMode
     end
 
     def begin_demo!
-      instance_eval(&@session.begin_demo)
+      instance_eval(&@session.begin_demo.call(**query_params.to_unsafe_h.deep_symbolize_keys))
     end
 
     def render_signinable_json
@@ -80,6 +80,10 @@ module DemoMode
 
     def options_params
       params.fetch(:options, {}).permit!
+    end
+
+    def query_params
+      params.permit(:redirect_to)
     end
   end
 end

--- a/app/models/helper/path_parser.rb
+++ b/app/models/helper/path_parser.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# https://github.com/plataformatec/devise/blob/88724e10adaf9ffd1d8dbfbaadda2b9d40de756a/lib/devise/controllers/store_location.rb#L34
+module Helper
+  class PathParser
+    class << self
+      def parse(value)
+        uri = parse_uri(value)
+        if uri
+          path = [uri.path.sub(%r{\A/+}, '/'), uri.query].compact.join('?')
+          [path, uri.fragment].compact.join('#')
+
+        end
+      end
+
+      private
+
+      def parse_uri(location)
+        location && URI.parse(location)
+      rescue URI::InvalidURIError
+        nil
+      end
+    end
+  end
+end

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -31,9 +31,16 @@ module DemoMode
       if block
         @begin_demo = block
       else
-        @begin_demo || proc do
-          sign_in @session.signinable
-          redirect_to main_app.root_path
+        @begin_demo || proc do |option|
+          proc do
+            sign_in @session.signinable
+
+            if option.present? && option[:redirect_to].present?
+              redirect_to option[:redirect_to]
+            else
+              redirect_to main_app.root_path
+            end
+          end
         end
       end
     end

--- a/spec/system/demo_splash_spec.rb
+++ b/spec/system/demo_splash_spec.rb
@@ -192,7 +192,7 @@ describe 'Demo Splash' do
           features << 'redirects to a 404'
 
           begin_demo do
-            redirect_to '/not_found_oh_no'
+            proc { redirect_to '/not_found_oh_no' }
           end
 
           sign_in_as { Widget.create! }


### PR DESCRIPTION
Update the session GET API to accept a `redirect_to` query parameter to override the demo's redirect_to URL. When the option is unavailable, we default to the original root path for the main app.

The current changeset includes a breaking change where the `being_demo` callback needs to wrap it's content with a proc.