### PR TITLE
FactoryBotExt: `around_each`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (3.0.0)
+    demo_mode (3.1.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/README.md
+++ b/README.md
@@ -472,7 +472,16 @@ begin_demo do
 end
 ```
 
-### FactoryBot `sequence` extension
+### FactoryBot extensions
+
+Factory bot ships two patches that may be manually loaded after loading FactoryBot:
+
+```ruby
+require 'factory_bot'
+require 'demo_mode/factory_bot_ext'
+```
+
+#### `sequence`
 
 `DemoMode` comes with a patch designed to be a drop-in replacement for
 [factory_bot](https://github.com/thoughtbot/factory_bot)'s `sequence` feature,
@@ -487,11 +496,19 @@ records in the DB (rather than starting at "Something 1" each time). This
 feature is necessary wherever you rely on `UNIQUE` constraints in the database,
 or uniqueness validations on your models.
 
-This patch must be manually loaded after loading FactoryBot:
+#### `around_each` hook
+
+Use `FactoryBot.around_each` to wrap all factory execution, which can be used to
+skip expensive callbacks/logging:
 
 ```ruby
-require 'factory_bot'
-require 'demo_mode/factory_bot_ext'
+FactoryBot.around_each do |&blk|
+  was_enabled = MyLogger.enabled?
+  MyLogger.disable!
+  blk.call
+ensure
+  MyLogger.enable! if was_enabled
+end
 ```
 
 #### Considerations

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.0.0)
+    demo_mode (3.1.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.0.0)
+    demo_mode (3.1.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.0.0)
+    demo_mode (3.1.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.0.0)
+    demo_mode (3.1.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.0.0)
+    demo_mode (3.1.0)
       actionpack (>= 6.1, < 8.1)
       activejob (>= 6.1, < 8.1)
       activerecord (>= 6.1, < 8.1)

--- a/lib/demo_mode/factory_bot_ext.rb
+++ b/lib/demo_mode/factory_bot_ext.rb
@@ -10,3 +10,25 @@ module FactoryBot
     alias sequence clever_sequence
   end
 end
+
+module DemoMode
+  module FactoryBotExt
+    def around_each(&block)
+      @around_each ||= ->(&blk) { blk.call }
+      if block_given?
+        previous = @around_each
+        @around_each = ->(&blk) { previous.call { block.call(&blk) } }
+      end
+      @around_each
+    end
+  end
+
+  module FactoryBotRunnerExt
+    def run(...)
+      ::FactoryBot.around_each.call { super }
+    end
+  end
+
+  ::FactoryBot.extend(FactoryBotExt)
+  ::FactoryBot::FactoryRunner.prepend(FactoryBotRunnerExt)
+end

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '3.0.0'
+  VERSION = '3.1.0'
 end

--- a/spec/demo_mode/factory_bot_ext_spec.rb
+++ b/spec/demo_mode/factory_bot_ext_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DemoMode::FactoryBotExt do
+  before do
+    stub_const('User', Struct.new(:name))
+  end
+
+  after do
+    FactoryBot.remove_instance_variable(:@around_each) if FactoryBot.instance_variable_defined?(:@around_each)
+    FactoryBot.factories.clear
+  end
+
+  let!(:factory) do
+    FactoryBot.define do
+      factory :user do
+        name { 'Test User' }
+      end
+    end
+  end
+
+  it 'does not interfere if no custom around_each is set' do
+    user = nil
+    expect { user = FactoryBot.build(:user) }.not_to raise_error
+    expect(user.name).to eq('Test User')
+  end
+
+  context 'when an around_each is set' do
+    let(:events) { [] }
+
+    before do
+      FactoryBot.around_each do |&blk|
+        events << :before
+        result = blk.call
+        result.tap { events << :after }
+      ensure
+        events << :ensure
+      end
+    end
+
+    it 'calls the around_each block when building a factory' do
+      user = FactoryBot.build(:user)
+
+      expect(events).to eq(%i(before after ensure))
+      expect(user.name).to eq('Test User')
+    end
+
+    context 'when the factory raises an error' do
+      let!(:factory) do
+        FactoryBot.define do
+          factory :user do
+            name { raise 'Intentional Error' }
+          end
+        end
+      end
+
+      it 'calls the ensure block' do
+        expect { FactoryBot.build(:user) }.to raise_error('Intentional Error')
+
+        expect(events).to eq(%i(before ensure))
+      end
+    end
+
+    context 'and a second around_each hooks is defined' do
+      before do
+        FactoryBot.around_each do |&blk|
+          events << :before_second
+          result = blk.call
+          result.tap { events << :after_second }
+        ensure
+          events << :ensure_second
+        end
+      end
+
+      it 'calls all around_each hooks in order' do
+        user = FactoryBot.build(:user)
+
+        expect(events).to eq(%i(before before_second after_second ensure_second after ensure))
+        expect(user.name).to eq('Test User')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use `FactoryBot.around_each` to wrap all factory execution, which can be used to
skip expensive callbacks/logging:

```ruby
FactoryBot.around_each do |&blk|
  was_enabled = MyLogger.enabled?
  MyLogger.disable!
  blk.call
ensure
  MyLogger.enable! if was_enabled
end
```

Note: For now, we are extracting this as a utility (as we use it internally), but we should also consider upstreaming useful capabilities into FactoryBot itself.

/no-platform