### PR TITLE
feat: sequence adjustment on uniqueness violations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri (1.0.4)
+    uri (1.1.1)
     useragent (0.16.11)
     webrick (1.9.1)
     websocket-driver (0.7.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (3.5.0)
+    demo_mode (3.6.0)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "net-imap", "~> 0.4.20"
-gem "nokogiri", "~> 1.18.9"
+gem "nokogiri", "~> 1.19.1"
 gem "securerandom", "~> 0.3.2"
 gem "with_transactional_lock", "~> 3.2.0"
 gem "zeitwerk", "~> 2.6.18"

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.5.0)
+    demo_mode (3.6.0)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)
@@ -134,11 +134,11 @@ GEM
       timeout
     net-smtp (0.5.1)
       net-protocol
-    nokogiri (1.18.10-arm64-darwin)
+    nokogiri (1.19.1-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-darwin)
+    nokogiri (1.19.1-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-gnu)
+    nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.7.1)
@@ -290,7 +290,7 @@ DEPENDENCIES
   factory_bot
   net-imap (~> 0.4.20)
   net-smtp
-  nokogiri (~> 1.18.9)
+  nokogiri (~> 1.19.1)
   pg
   railties (~> 7.2.0)
   rspec-rails

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "net-imap", "~> 0.4.20"
-gem "nokogiri", "~> 1.18.9"
+gem "nokogiri", "~> 1.19.1"
 gem "securerandom", "~> 0.3.2"
 gem "with_transactional_lock", "~> 3.2.0"
 gem "zeitwerk", "~> 2.6.18"

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.5.0)
+    demo_mode (3.6.0)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)
@@ -137,11 +137,11 @@ GEM
       timeout
     net-smtp (0.5.1)
       net-protocol
-    nokogiri (1.18.10-arm64-darwin)
+    nokogiri (1.19.1-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-darwin)
+    nokogiri (1.19.1-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-gnu)
+    nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -301,7 +301,7 @@ DEPENDENCIES
   factory_bot
   net-imap (~> 0.4.20)
   net-smtp
-  nokogiri (~> 1.18.9)
+  nokogiri (~> 1.19.1)
   pg
   railties (~> 8.0.0)
   rspec-rails

--- a/gemfiles/rails_8_1.gemfile
+++ b/gemfiles/rails_8_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "net-imap", "~> 0.4.20"
-gem "nokogiri", "~> 1.18.9"
+gem "nokogiri", "~> 1.19.1"
 gem "securerandom", "~> 0.3.2"
 gem "with_transactional_lock", "~> 3.2.0"
 gem "zeitwerk", "~> 2.6.18"

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.5.0)
+    demo_mode (3.6.0)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)
@@ -136,9 +136,9 @@ GEM
       timeout
     net-smtp (0.5.1)
       net-protocol
-    nokogiri (1.18.10-arm64-darwin)
+    nokogiri (1.19.1-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-gnu)
+    nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -293,7 +293,7 @@ DEPENDENCIES
   factory_bot
   net-imap (~> 0.4.20)
   net-smtp
-  nokogiri (~> 1.18.9)
+  nokogiri (~> 1.19.1)
   pg
   railties (~> 8.1.0)
   rspec-rails

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -7,7 +7,7 @@ require_relative 'clever_sequence/postgres_backend'
 class CleverSequence
   DEFAULT_BLOCK = ->(i) { i }
 
-  thread_cattr_accessor(:sequences) { {} }
+  cattr_accessor(:sequences) { {} }
   cattr_accessor(:use_database_sequences) { false }
   cattr_accessor(:enforce_sequences_exist) { false }
   cattr_accessor(:retry_on_uniqueness_violation) { true }

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -85,18 +85,28 @@ class CleverSequence
   private
 
   def last_value
-    thread_local_last_values[self]
+    if klass
+      Thread.current[:clever_sequence_last_value]&.dig(klass.name, attribute)
+    else
+      @last_value
+    end
   end
 
   def last_value=(value)
-    thread_local_last_values[self] = value
+    if klass
+      Thread.current[:clever_sequence_last_value] ||= {}
+      Thread.current[:clever_sequence_last_value][klass.name] ||= {}
+      Thread.current[:clever_sequence_last_value][klass.name][attribute] = value
+    else
+      @last_value = value
+    end
   end
 
   def clear_last_value
-    thread_local_last_values.delete(self)
-  end
-
-  def thread_local_last_values
-    Thread.current[:clever_sequence_last_value] ||= {}.compare_by_identity
+    if klass
+      Thread.current[:clever_sequence_last_value]&.[](klass.name)&.delete(attribute)
+    else
+      @last_value = nil
+    end
   end
 end

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -33,10 +33,7 @@ class CleverSequence
     end
 
     def snapshot_last_values
-      sequences.each_with_object({}) do |((klass_name, attribute), seq), hash|
-        value = seq.last_value_if_set
-        hash[[klass_name, attribute]] = value if value
-      end
+      sequences.transform_values(&:last_value_if_set).compact
     end
 
     def next(klass, name)

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -10,10 +10,12 @@ class CleverSequence
   cattr_accessor(:sequences) { {} }
   cattr_accessor(:use_database_sequences) { false }
   cattr_accessor(:enforce_sequences_exist) { false }
+  cattr_accessor(:retry_on_uniqueness_violation) { true }
 
   class << self
     alias use_database_sequences? use_database_sequences
     alias enforce_sequences_exist? enforce_sequences_exist
+    alias retry_on_uniqueness_violation? retry_on_uniqueness_violation
 
     def backend
       use_database_sequences? ? PostgresBackend : InMemoryBackend

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -33,7 +33,7 @@ class CleverSequence
     end
 
     def snapshot_last_values
-      sequences.transform_values(&:last_value_if_set).compact
+      sequences.transform_values { |seq| seq.send(:last_value) }.compact
     end
 
     def next(klass, name)
@@ -70,20 +70,16 @@ class CleverSequence
   end
 
   def last
-    block.call(last_value)
-  end
-
-  def last_value_if_set
-    @last_value if instance_variable_defined?(:@last_value)
+    block.call(@last_value || self.class.backend.starting_value(klass, attribute, block))
   end
 
   def reset!
-    remove_instance_variable(:@last_value) if instance_variable_defined?(:@last_value)
+    @last_value = nil
   end
 
   private
 
   def last_value
-    @last_value || self.class.backend.starting_value(klass, attribute, block)
+    @last_value
   end
 end

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -70,7 +70,7 @@ class CleverSequence
     else
       (last_value || 0) + 1
     end
-    set_last_value(value)
+    self.last_value = value
     last
   end
 
@@ -85,15 +85,18 @@ class CleverSequence
   private
 
   def last_value
-    Thread.current[:clever_sequence_last_value]&.[](object_id)
+    thread_local_last_values[self]
   end
 
-  def set_last_value(value)
-    Thread.current[:clever_sequence_last_value] ||= {}
-    Thread.current[:clever_sequence_last_value][object_id] = value
+  def last_value=(value)
+    thread_local_last_values[self] = value
   end
 
   def clear_last_value
-    Thread.current[:clever_sequence_last_value]&.delete(object_id)
+    thread_local_last_values.delete(self)
+  end
+
+  def thread_local_last_values
+    Thread.current[:clever_sequence_last_value] ||= {}.compare_by_identity
   end
 end

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -56,7 +56,6 @@ class CleverSequence
   def initialize(attribute, &block)
     @attribute = attribute.to_s
     @block = block || DEFAULT_BLOCK
-    @last_value_mutex = Mutex.new
   end
 
   def with_class(klass)
@@ -66,26 +65,35 @@ class CleverSequence
   end
 
   def next
-    @last_value_mutex.synchronize do
-      @last_value = if klass
-        self.class.backend.nextval(klass, attribute, block)
-      else
-        (@last_value || 0) + 1
-      end
+    value = if klass
+      self.class.backend.nextval(klass, attribute, block)
+    else
+      (last_value || 0) + 1
     end
+    set_last_value(value)
     last
   end
 
   def last
-    value = @last_value_mutex.synchronize { @last_value }
-    block.call(value || (klass ? self.class.backend.starting_value(klass, attribute, block) : 0))
+    block.call(last_value || (klass ? self.class.backend.starting_value(klass, attribute, block) : 0))
   end
 
   def reset!
-    @last_value_mutex.synchronize { @last_value = nil }
+    clear_last_value
   end
 
   private
 
-  attr_reader :last_value
+  def last_value
+    Thread.current[:clever_sequence_last_value]&.[](object_id)
+  end
+
+  def set_last_value(value)
+    Thread.current[:clever_sequence_last_value] ||= {}
+    Thread.current[:clever_sequence_last_value][object_id] = value
+  end
+
+  def clear_last_value
+    Thread.current[:clever_sequence_last_value]&.delete(object_id)
+  end
 end

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -24,6 +24,11 @@ class CleverSequence
       sequences.each_value(&:reset!)
     end
 
+    def with_sequence_adjustment(&block)
+      reset!
+      backend.with_sequence_adjustment(&block)
+    end
+
     def next(klass, name)
       lookup(klass, name)&.next
     end

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -79,7 +79,5 @@ class CleverSequence
 
   private
 
-  def last_value
-    @last_value
-  end
+  attr_reader :last_value
 end

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -7,7 +7,7 @@ require_relative 'clever_sequence/postgres_backend'
 class CleverSequence
   DEFAULT_BLOCK = ->(i) { i }
 
-  cattr_accessor(:sequences) { {} }
+  thread_cattr_accessor(:sequences) { {} }
   cattr_accessor(:use_database_sequences) { false }
   cattr_accessor(:enforce_sequences_exist) { false }
   cattr_accessor(:retry_on_uniqueness_violation) { true }

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -26,9 +26,9 @@ class CleverSequence
       sequences.each_value(&:reset!)
     end
 
-    def with_sequence_adjustment(&block)
+    def with_sequence_adjustment(&)
       reset!
-      backend.with_sequence_adjustment(&block)
+      backend.with_sequence_adjustment(&)
     end
 
     def next(klass, name)

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -56,6 +56,7 @@ class CleverSequence
   def initialize(attribute, &block)
     @attribute = attribute.to_s
     @block = block || DEFAULT_BLOCK
+    @nil_klass_mutex = Mutex.new
   end
 
   def with_class(klass)
@@ -65,12 +66,16 @@ class CleverSequence
   end
 
   def next
-    @last_value = self.class.backend.nextval(klass, attribute, block)
+    @last_value = if klass
+      self.class.backend.nextval(klass, attribute, block)
+    else
+      @nil_klass_mutex.synchronize { (@last_value || 0) + 1 }
+    end
     last
   end
 
   def last
-    block.call(@last_value || self.class.backend.starting_value(klass, attribute, block))
+    block.call(@last_value || (klass ? self.class.backend.starting_value(klass, attribute, block) : 0))
   end
 
   def reset!

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -56,7 +56,7 @@ class CleverSequence
   def initialize(attribute, &block)
     @attribute = attribute.to_s
     @block = block || DEFAULT_BLOCK
-    @nil_klass_mutex = Mutex.new
+    @last_value_mutex = Mutex.new
   end
 
   def with_class(klass)
@@ -66,20 +66,23 @@ class CleverSequence
   end
 
   def next
-    @last_value = if klass
-      self.class.backend.nextval(klass, attribute, block)
-    else
-      @nil_klass_mutex.synchronize { (@last_value || 0) + 1 }
+    @last_value_mutex.synchronize do
+      @last_value = if klass
+        self.class.backend.nextval(klass, attribute, block)
+      else
+        (@last_value || 0) + 1
+      end
     end
     last
   end
 
   def last
-    block.call(@last_value || (klass ? self.class.backend.starting_value(klass, attribute, block) : 0))
+    value = @last_value_mutex.synchronize { @last_value }
+    block.call(value || (klass ? self.class.backend.starting_value(klass, attribute, block) : 0))
   end
 
   def reset!
-    @last_value = nil
+    @last_value_mutex.synchronize { @last_value = nil }
   end
 
   private

--- a/lib/demo_mode/clever_sequence.rb
+++ b/lib/demo_mode/clever_sequence.rb
@@ -27,8 +27,16 @@ class CleverSequence
     end
 
     def with_sequence_adjustment(&)
+      last_values = snapshot_last_values
       reset!
-      backend.with_sequence_adjustment(&)
+      backend.with_sequence_adjustment(last_values:, &)
+    end
+
+    def snapshot_last_values
+      sequences.each_with_object({}) do |((klass_name, attribute), seq), hash|
+        value = seq.last_value_if_set
+        hash[[klass_name, attribute]] = value if value
+      end
     end
 
     def next(klass, name)
@@ -66,6 +74,10 @@ class CleverSequence
 
   def last
     block.call(last_value)
+  end
+
+  def last_value_if_set
+    @last_value if instance_variable_defined?(:@last_value)
   end
 
   def reset!

--- a/lib/demo_mode/clever_sequence/in_memory_backend.rb
+++ b/lib/demo_mode/clever_sequence/in_memory_backend.rb
@@ -22,6 +22,13 @@ class CleverSequence
         end
       end
 
+      def with_sequence_adjustment
+        # No-op for InMemoryBackend. After reset!, nextval already
+        # recalculates from the database via starting_value/LowerBoundFinder,
+        # which finds the correct lower bound past existing data.
+        yield
+      end
+
       def sequence_state
         @sequence_state ||= {}
       end

--- a/lib/demo_mode/clever_sequence/in_memory_backend.rb
+++ b/lib/demo_mode/clever_sequence/in_memory_backend.rb
@@ -22,7 +22,7 @@ class CleverSequence
         end
       end
 
-      def with_sequence_adjustment
+      def with_sequence_adjustment(**)
         # No-op for InMemoryBackend. After reset!, nextval already
         # recalculates from the database via starting_value/LowerBoundFinder,
         # which finds the correct lower bound past existing data.

--- a/lib/demo_mode/clever_sequence/lower_bound_finder.rb
+++ b/lib/demo_mode/clever_sequence/lower_bound_finder.rb
@@ -1,9 +1,20 @@
 # frozen_string_literal: true
 
 class CleverSequence
-  LowerBoundFinder = Struct.new(:klass, :column_name, :block) do
+  class LowerBoundFinder
+    MUTEXES = Hash.new { |h, k| h[k] = Mutex.new }
+    private_constant :MUTEXES
+
+    attr_reader :klass, :column_name, :block
+
+    def initialize(klass, column_name, block)
+      @klass = klass
+      @column_name = column_name
+      @block = block
+    end
+
     def lower_bound(hint: nil)
-      ActiveRecord::Base.with_transactional_lock("lower-bound-#{klass}-#{column_name}") do
+      with_lock do
         start = hint && hint >= 1 ? hint : 1
         # If the hint overshoots the actual data, return it directly.
         # The hint is a previously-known high-water mark, so it's a valid
@@ -17,6 +28,14 @@ class CleverSequence
     end
 
     private
+
+    def with_lock(&)
+      if ActiveRecord::Base.connection.adapter_name.casecmp?('postgresql')
+        ActiveRecord::Base.with_transactional_lock("lower-bound-#{klass}-#{column_name}", &)
+      else
+        MUTEXES["lower-bound-#{klass}-#{column_name}"].synchronize(&)
+      end
+    end
 
     def _lower_bound(current, lower, upper)
       if exists?(current)

--- a/lib/demo_mode/clever_sequence/lower_bound_finder.rb
+++ b/lib/demo_mode/clever_sequence/lower_bound_finder.rb
@@ -2,9 +2,6 @@
 
 class CleverSequence
   class LowerBoundFinder
-    MUTEXES = Hash.new { |h, k| h[k] = Mutex.new }
-    private_constant :MUTEXES
-
     attr_reader :klass, :column_name, :block
 
     def initialize(klass, column_name, block)
@@ -33,7 +30,7 @@ class CleverSequence
       if ActiveRecord::Base.connection.adapter_name.casecmp?('postgresql')
         ActiveRecord::Base.with_transactional_lock("lower-bound-#{klass}-#{column_name}", &)
       else
-        MUTEXES["lower-bound-#{klass}-#{column_name}"].synchronize(&)
+        yield
       end
     end
 

--- a/lib/demo_mode/clever_sequence/lower_bound_finder.rb
+++ b/lib/demo_mode/clever_sequence/lower_bound_finder.rb
@@ -3,15 +3,17 @@
 class CleverSequence
   LowerBoundFinder = Struct.new(:klass, :column_name, :block) do
     def lower_bound(hint: nil)
-      start = hint && hint >= 1 ? hint : 1
-      # If the hint overshoots the actual data, return it directly.
-      # The hint is a previously-known high-water mark, so it's a valid
-      # lower bound. Callers pass the result through GREATEST against the
-      # PG sequence, so a higher value is always safe and avoids a costly
-      # binary search back down to data that won't be used anyway.
-      return hint if start > 1 && !exists?(start)
+      ActiveRecord::Base.with_transactional_lock("lower-bound-#{klass}-#{column_name}") do
+        start = hint && hint >= 1 ? hint : 1
+        # If the hint overshoots the actual data, return it directly.
+        # The hint is a previously-known high-water mark, so it's a valid
+        # lower bound. Callers pass the result through GREATEST against the
+        # PG sequence, so a higher value is always safe and avoids a costly
+        # binary search back down to data that won't be used anyway.
+        next hint if start > 1 && !exists?(start)
 
-      _lower_bound(start, 0, Float::INFINITY)
+        _lower_bound(start, 0, Float::INFINITY)
+      end
     end
 
     private

--- a/lib/demo_mode/clever_sequence/lower_bound_finder.rb
+++ b/lib/demo_mode/clever_sequence/lower_bound_finder.rb
@@ -10,6 +10,7 @@ class CleverSequence
       # PG sequence, so a higher value is always safe and avoids a costly
       # binary search back down to data that won't be used anyway.
       return hint if start > 1 && !exists?(start)
+
       _lower_bound(start, 0, Float::INFINITY)
     end
 

--- a/lib/demo_mode/clever_sequence/lower_bound_finder.rb
+++ b/lib/demo_mode/clever_sequence/lower_bound_finder.rb
@@ -2,17 +2,32 @@
 
 class CleverSequence
   LowerBoundFinder = Struct.new(:klass, :column_name, :block) do
-    def lower_bound(current = 1, lower = 0, upper = Float::INFINITY)
+    def lower_bound(hint: nil)
+      start = hint && hint >= 1 ? hint : 1
+      # If the hint doesn't exist, fall back to starting from 1.
+      # This avoids the next_between(0, n) = 0 trap that occurs when
+      # binary searching downward from a non-existent hint value.
+      start = 1 if start > 1 && !exists?(start)
+      _lower_bound(start, 0, Float::INFINITY)
+    end
+
+    private
+
+    def _lower_bound(current, lower, upper)
       if exists?(current)
-        lower_bound(next_between(current, upper), [current, lower].max, upper)
+        # When upper is at most current + 1, we know current is the highest
+        # existing value (upper is always a known-false or Infinity bound).
+        # next_between would return current due to integer division, causing
+        # infinite recursion, so return early.
+        return current if upper <= current + 1
+
+        _lower_bound(next_between(current, upper), [current, lower].max, upper)
       elsif current - lower > 1
-        lower_bound(next_between(lower, current), lower, [current, upper].min)
+        _lower_bound(next_between(lower, current), lower, [current, upper].min)
       else # current should == lower + 1
         lower
       end
     end
-
-    private
 
     def next_between(lower, upper)
       [((lower + 1) / 2) + (upper / 2), lower * 2].min

--- a/lib/demo_mode/clever_sequence/lower_bound_finder.rb
+++ b/lib/demo_mode/clever_sequence/lower_bound_finder.rb
@@ -4,10 +4,12 @@ class CleverSequence
   LowerBoundFinder = Struct.new(:klass, :column_name, :block) do
     def lower_bound(hint: nil)
       start = hint && hint >= 1 ? hint : 1
-      # If the hint doesn't exist, fall back to starting from 1.
-      # This avoids the next_between(0, n) = 0 trap that occurs when
-      # binary searching downward from a non-existent hint value.
-      start = 1 if start > 1 && !exists?(start)
+      # If the hint overshoots the actual data, return it directly.
+      # The hint is a previously-known high-water mark, so it's a valid
+      # lower bound. Callers pass the result through GREATEST against the
+      # PG sequence, so a higher value is always safe and avoids a costly
+      # binary search back down to data that won't be used anyway.
+      return hint if start > 1 && !exists?(start)
       _lower_bound(start, 0, Float::INFINITY)
     end
 

--- a/lib/demo_mode/clever_sequence/postgres_backend.rb
+++ b/lib/demo_mode/clever_sequence/postgres_backend.rb
@@ -50,62 +50,12 @@ class CleverSequence
       def nextval(klass, attribute, block)
         @sequence_monitor.synchronize do
           name = sequence_name(klass, attribute)
-          Rails.logger.info("[DemoMode] nextval called for #{klass.name}##{attribute} (sequence: #{name})")
+          log "[DemoMode] nextval called for #{klass.name}##{attribute} (sequence: #{name})"
 
           if sequence_exists?(name)
-            # On first use with adjustment enabled, ensure sequence is past existing data
-            if adjust_sequences_enabled? && !sequence_cache[name].is_a?(SequenceResult::Exists)
-              Rails.logger.info("[DemoMode] Sequence adjustment enabled and #{name} not yet adjusted, adjusting now for #{klass.name}##{attribute}")
-              adjust_sequence_if_needed(name, klass, attribute, block)
-            end
-            sequence_cache[name] = SequenceResult::Exists.new(name)
-
-            result = ActiveRecord::Base.connection.execute(
-              "SELECT nextval('#{name}')",
-            )
-            value = result.first['nextval'].to_i
-            Rails.logger.info("[DemoMode] nextval for #{klass.name}##{attribute} returned #{value} from postgres sequence #{name}")
-            value
+            nextval_from_sequence(name, klass, attribute, block)
           else
-            # Check if we already have this sequence cached as Missing
-            cached = sequence_cache[name]
-
-            if cached.is_a?(SequenceResult::Missing)
-              # Increment from cached value instead of recalculating from DB
-              # This handles the case where transactions are rolled back but we
-              # need to continue generating unique values
-              next_value = cached.calculated_start_value + 1
-              Rails.logger.info("[DemoMode] Sequence #{name} missing (cached), incrementing from cached value #{cached.calculated_start_value} to #{next_value} for #{klass.name}##{attribute}")
-              sequence_cache[name] = SequenceResult::Missing.new(
-                sequence_name: name,
-                klass: klass,
-                attribute: attribute,
-                calculated_start_value: next_value,
-              )
-            else
-              # First time seeing this missing sequence - calculate from DB
-              start_value = calculate_sequence_value(klass, attribute, block)
-              next_value = start_value + 1
-              Rails.logger.info("[DemoMode] Sequence #{name} missing (first encounter), calculated start_value=#{start_value}, returning next_value=#{next_value} for #{klass.name}##{attribute}")
-              sequence_cache[name] = SequenceResult::Missing.new(
-                sequence_name: name,
-                klass: klass,
-                attribute: attribute,
-                calculated_start_value: next_value,
-              )
-            end
-
-            if CleverSequence.enforce_sequences_exist
-              Rails.logger.warn("[DemoMode] Raising SequenceNotFoundError for #{klass.name}##{attribute} (sequence: #{name}, enforce_sequences_exist is enabled)")
-              raise SequenceNotFoundError.new(
-                sequence_name: name,
-                klass: klass,
-                attribute: attribute,
-              )
-            else
-              Rails.logger.info("[DemoMode] nextval for #{klass.name}##{attribute} returning #{next_value} (fallback, sequence #{name} does not exist)")
-              next_value
-            end
+            nextval_without_sequence(name, klass, attribute, block)
           end
         end
       end
@@ -125,59 +75,107 @@ class CleverSequence
 
       private
 
+      def log(message, level: :info)
+        Rails.logger.public_send(level, message)
+      end
+
+      def nextval_from_sequence(name, klass, attribute, block)
+        # On first use with adjustment enabled, ensure sequence is past existing data
+        if adjust_sequences_enabled? && !sequence_cache[name].is_a?(SequenceResult::Exists)
+          log "[DemoMode] Sequence adjustment enabled, adjusting #{name}"
+          adjust_sequence_if_needed(name, klass, attribute, block)
+        end
+        sequence_cache[name] = SequenceResult::Exists.new(name)
+
+        result = ActiveRecord::Base.connection.execute(
+          "SELECT nextval('#{name}')",
+        )
+        value = result.first['nextval'].to_i
+        log "[DemoMode] nextval for #{klass.name}##{attribute} returned #{value}"
+        value
+      end
+
+      def nextval_without_sequence(name, klass, attribute, block)
+        next_value = calculate_next_missing_value(name, klass, attribute, block)
+
+        if CleverSequence.enforce_sequences_exist
+          log "[DemoMode] Raising SequenceNotFoundError for #{name}", level: :warn
+          raise SequenceNotFoundError.new(
+            sequence_name: name, klass: klass, attribute: attribute,
+          )
+        else
+          log "[DemoMode] nextval returning #{next_value} (fallback, #{name} missing)"
+          next_value
+        end
+      end
+
+      def calculate_next_missing_value(name, klass, attribute, block)
+        cached = sequence_cache[name]
+
+        next_value = if cached.is_a?(SequenceResult::Missing)
+          cached.calculated_start_value + 1
+        else
+          calculate_sequence_value(klass, attribute, block) + 1
+        end
+
+        sequence_cache[name] = SequenceResult::Missing.new(
+          sequence_name: name, klass: klass,
+          attribute: attribute, calculated_start_value: next_value
+        )
+
+        next_value
+      end
+
       def adjust_sequences_enabled?
         Thread.current[:clever_sequence_adjust_sequences_enabled]
       end
 
       def sequence_exists?(sequence_name)
         if sequence_cache.key?(sequence_name)
-          case sequence_cache[sequence_name]
-          when SequenceResult::Exists
-            Rails.logger.info("[DemoMode] Sequence #{sequence_name} exists (cached)")
-            return true
-          else
-            Rails.logger.info("[DemoMode] Sequence #{sequence_name} does not exist (cached as #{sequence_cache[sequence_name].class.name})")
-            return false
-          end
+          exists = sequence_cache[sequence_name].is_a?(SequenceResult::Exists)
+          log "[DemoMode] Sequence #{sequence_name} #{exists ? 'exists' : 'missing'} (cached)"
+          return exists
         end
 
         exists = ActiveRecord::Base.connection.execute(
-          "SELECT 1 FROM information_schema.sequences WHERE sequence_name = '#{sequence_name}' LIMIT 1",
+          "SELECT 1 FROM information_schema.sequences " \
+          "WHERE sequence_name = '#{sequence_name}' LIMIT 1",
         ).any?
-        Rails.logger.info("[DemoMode] Sequence #{sequence_name} #{exists ? 'found' : 'not found'} in information_schema")
+        log "[DemoMode] Sequence #{sequence_name} #{exists ? 'found' : 'not found'}"
         exists
       end
 
       def calculate_sequence_value(klass, attribute, block)
         column_name = klass.attribute_aliases.fetch(attribute.to_s, attribute.to_s)
         unless klass.column_names.include?(column_name)
-          Rails.logger.warn("[DemoMode] Column #{column_name} not found on #{klass.name}, returning 0 for sequence value calculation")
+          log "[DemoMode] Column #{column_name} not found on #{klass.name}", level: :warn
           return 0
         end
 
         value = ActiveRecord::Base.with_transactional_lock("lower-bound-#{klass}-#{column_name}") do
           LowerBoundFinder.new(klass, column_name, block).lower_bound
         end
-        Rails.logger.info("[DemoMode] Calculated sequence value for #{klass.name}##{attribute} (column: #{column_name}): #{value}")
+        log "[DemoMode] Calculated sequence value for #{klass.name}##{attribute}: #{value}"
         value
       end
 
       def adjust_sequence_if_needed(sequence_name, klass, attribute, block)
         max_value = calculate_sequence_value(klass, attribute, block)
         if max_value < 1
-          Rails.logger.info("[DemoMode] No adjustment needed for sequence #{sequence_name} (#{klass.name}##{attribute}), max_value=#{max_value}")
+          log "[DemoMode] No adjustment needed for #{sequence_name}"
           return
         end
 
-        Rails.logger.info("[DemoMode] Adjusting sequence #{sequence_name} for #{klass.name}##{attribute} to at least #{max_value}")
+        log "[DemoMode] Adjusting #{sequence_name} to at least #{max_value}"
         # setval sets the sequence's last_value. With the default 3rd argument (true),
         # the next nextval() will return last_value + 1.
         # We only want to advance (never go backwards), so we use GREATEST.
         result = ActiveRecord::Base.connection.execute(<<~SQL.squish)
-          SELECT setval('#{sequence_name}', GREATEST(#{max_value}, (SELECT last_value FROM #{sequence_name})))
+          SELECT setval('#{sequence_name}',
+            GREATEST(#{max_value}, (SELECT last_value FROM #{sequence_name})))
         SQL
         new_last_value = result.first['setval'].to_i
-        Rails.logger.info("[DemoMode] Sequence #{sequence_name} adjusted, new last_value=#{new_last_value} (next nextval will return #{new_last_value + 1})")
+        log "[DemoMode] #{sequence_name} adjusted to #{new_last_value}"
       end
     end
   end

--- a/lib/demo_mode/clever_sequence/postgres_backend.rb
+++ b/lib/demo_mode/clever_sequence/postgres_backend.rb
@@ -3,9 +3,6 @@
 class CleverSequence
   module PostgresBackend
     SEQUENCE_PREFIX = 'cs_'
-    SEQUENCE_CACHE_KEY = :clever_sequence_cache
-    LAST_VALUES_KEY = :clever_sequence_last_values
-    ADJUSTMENT_ENABLED_KEY = :clever_sequence_adjust_sequences_enabled
 
     class SequenceNotFoundError < StandardError
       attr_reader :sequence_name, :klass, :attribute
@@ -28,7 +25,7 @@ class CleverSequence
 
     class << self
       def reset!
-        Thread.current[SEQUENCE_CACHE_KEY] = {}
+        Thread.current[:clever_sequence_cache] = {}
       end
 
       def starting_value(klass, attribute, block)
@@ -36,15 +33,15 @@ class CleverSequence
       end
 
       def with_sequence_adjustment(last_values: {})
-        previous = Thread.current[ADJUSTMENT_ENABLED_KEY]
-        previous_last_values = Thread.current[LAST_VALUES_KEY]
+        previous = Thread.current[:clever_sequence_adjustment_enabled]
+        previous_last_values = Thread.current[:clever_sequence_last_values]
         Rails.logger.info("[DemoMode] Enabling sequence adjustment for retry")
-        Thread.current[ADJUSTMENT_ENABLED_KEY] = true
-        Thread.current[LAST_VALUES_KEY] = last_values
+        Thread.current[:clever_sequence_adjustment_enabled] = true
+        Thread.current[:clever_sequence_last_values] = last_values
         yield
       ensure
-        Thread.current[ADJUSTMENT_ENABLED_KEY] = previous
-        Thread.current[LAST_VALUES_KEY] = previous_last_values
+        Thread.current[:clever_sequence_adjustment_enabled] = previous
+        Thread.current[:clever_sequence_last_values] = previous_last_values
         Rails.logger.info("[DemoMode] Disabled sequence adjustment")
       end
 
@@ -69,7 +66,7 @@ class CleverSequence
       end
 
       def sequence_cache
-        Thread.current[SEQUENCE_CACHE_KEY] ||= {}
+        Thread.current[:clever_sequence_cache] ||= {}
       end
 
       private
@@ -126,7 +123,7 @@ class CleverSequence
       end
 
       def adjust_sequences_enabled?
-        Thread.current[ADJUSTMENT_ENABLED_KEY]
+        Thread.current[:clever_sequence_adjustment_enabled]
       end
 
       def sequence_exists?(sequence_name)
@@ -159,7 +156,7 @@ class CleverSequence
       end
 
       def hint_for(klass, attribute)
-        last_values = Thread.current[LAST_VALUES_KEY]
+        last_values = Thread.current[:clever_sequence_last_values]
         last_values && last_values[[klass.name, attribute.to_s]]
       end
 

--- a/lib/demo_mode/clever_sequence/postgres_backend.rb
+++ b/lib/demo_mode/clever_sequence/postgres_backend.rb
@@ -4,6 +4,8 @@ class CleverSequence
   module PostgresBackend
     SEQUENCE_PREFIX = 'cs_'
     SEQUENCE_CACHE_KEY = :clever_sequence_cache
+    LAST_VALUES_KEY = :clever_sequence_last_values
+    ADJUSTMENT_ENABLED_KEY = :clever_sequence_adjust_sequences_enabled
 
     class SequenceNotFoundError < StandardError
       attr_reader :sequence_name, :klass, :attribute
@@ -33,13 +35,16 @@ class CleverSequence
         calculate_sequence_value(klass, attribute, block)
       end
 
-      def with_sequence_adjustment
-        previous = Thread.current[:clever_sequence_adjust_sequences_enabled]
+      def with_sequence_adjustment(last_values: {})
+        previous = Thread.current[ADJUSTMENT_ENABLED_KEY]
+        previous_last_values = Thread.current[LAST_VALUES_KEY]
         Rails.logger.info("[DemoMode] Enabling sequence adjustment for retry")
-        Thread.current[:clever_sequence_adjust_sequences_enabled] = true
+        Thread.current[ADJUSTMENT_ENABLED_KEY] = true
+        Thread.current[LAST_VALUES_KEY] = last_values
         yield
       ensure
-        Thread.current[:clever_sequence_adjust_sequences_enabled] = previous
+        Thread.current[ADJUSTMENT_ENABLED_KEY] = previous
+        Thread.current[LAST_VALUES_KEY] = previous_last_values
         Rails.logger.info("[DemoMode] Disabled sequence adjustment")
       end
 
@@ -121,7 +126,7 @@ class CleverSequence
       end
 
       def adjust_sequences_enabled?
-        Thread.current[:clever_sequence_adjust_sequences_enabled]
+        Thread.current[ADJUSTMENT_ENABLED_KEY]
       end
 
       def sequence_exists?(sequence_name)
@@ -139,7 +144,7 @@ class CleverSequence
         exists
       end
 
-      def calculate_sequence_value(klass, attribute, block)
+      def calculate_sequence_value(klass, attribute, block, hint: nil)
         column_name = klass.attribute_aliases.fetch(attribute.to_s, attribute.to_s)
         unless klass.column_names.include?(column_name)
           log "[DemoMode] Column #{column_name} not found on #{klass.name}", level: :warn
@@ -147,15 +152,21 @@ class CleverSequence
         end
 
         value = ActiveRecord::Base.with_transactional_lock("lower-bound-#{klass}-#{column_name}") do
-          LowerBoundFinder.new(klass, column_name, block).lower_bound
+          LowerBoundFinder.new(klass, column_name, block).lower_bound(hint:)
         end
-        log "[DemoMode] Calculated sequence value for #{klass.name}##{attribute}: #{value}"
+        log "[DemoMode] Calculated sequence value for #{klass.name}##{attribute}: #{value} (hint: #{hint || 'none'})"
         value
+      end
+
+      def hint_for(klass, attribute)
+        last_values = Thread.current[LAST_VALUES_KEY]
+        last_values && last_values[[klass.name, attribute.to_s]]
       end
 
       def adjust_sequence_if_needed(sequence_name, klass, attribute, block)
         ActiveRecord::Base.with_transactional_lock("adjust-sequence-#{sequence_name}") do
-          max_value = calculate_sequence_value(klass, attribute, block)
+          hint = hint_for(klass, attribute)
+          max_value = calculate_sequence_value(klass, attribute, block, hint:)
           if max_value < 1
             log "[DemoMode] No adjustment needed for #{sequence_name}"
             return

--- a/lib/demo_mode/clever_sequence/postgres_backend.rb
+++ b/lib/demo_mode/clever_sequence/postgres_backend.rb
@@ -148,9 +148,7 @@ class CleverSequence
           return 0
         end
 
-        value = ActiveRecord::Base.with_transactional_lock("lower-bound-#{klass}-#{column_name}") do
-          LowerBoundFinder.new(klass, column_name, block).lower_bound(hint:)
-        end
+        value = LowerBoundFinder.new(klass, column_name, block).lower_bound(hint:)
         log "[DemoMode] Calculated sequence value for #{klass.name}##{attribute}: #{value} (hint: #{hint || 'none'})"
         value
       end

--- a/lib/demo_mode/clever_sequence/postgres_backend.rb
+++ b/lib/demo_mode/clever_sequence/postgres_backend.rb
@@ -34,11 +34,12 @@ class CleverSequence
       end
 
       def with_sequence_adjustment
+        previous = Thread.current[:clever_sequence_adjust_sequences_enabled]
         Rails.logger.info("[DemoMode] Enabling sequence adjustment for retry")
         Thread.current[:clever_sequence_adjust_sequences_enabled] = true
         yield
       ensure
-        Thread.current[:clever_sequence_adjust_sequences_enabled] = false
+        Thread.current[:clever_sequence_adjust_sequences_enabled] = previous
         Rails.logger.info("[DemoMode] Disabled sequence adjustment")
       end
 

--- a/lib/demo_mode/clever_sequence/postgres_backend.rb
+++ b/lib/demo_mode/clever_sequence/postgres_backend.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'monitor'
+
 class CleverSequence
   module PostgresBackend
     SEQUENCE_PREFIX = 'cs_'
@@ -23,6 +25,10 @@ class CleverSequence
       Missing = Data.define(:sequence_name, :klass, :attribute, :calculated_start_value)
     end
 
+    # Initialized eagerly at load time (single-threaded), so no race on creation.
+    # Monitor is reentrant, allowing nextval -> sequence_exists? nesting.
+    @sequence_monitor = Monitor.new
+
     class << self
       def reset!
         @sequence_cache = {}
@@ -32,34 +38,74 @@ class CleverSequence
         calculate_sequence_value(klass, attribute, block)
       end
 
+      def with_sequence_adjustment
+        Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Enabling sequence adjustment for retry")
+        Thread.current[:clever_sequence_adjust_sequences_enabled] = true
+        yield
+      ensure
+        Thread.current[:clever_sequence_adjust_sequences_enabled] = false
+        Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Disabled sequence adjustment")
+      end
+
       def nextval(klass, attribute, block)
-        name = sequence_name(klass, attribute)
+        @sequence_monitor.synchronize do
+          name = sequence_name(klass, attribute)
+          Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] nextval called for #{klass.name}##{attribute} (sequence: #{name})")
 
-        if sequence_exists?(name)
-          sequence_cache[name] = SequenceResult::Exists.new(name)
+          if sequence_exists?(name)
+            # On first use with adjustment enabled, ensure sequence is past existing data
+            if adjust_sequences_enabled? && !sequence_cache[name].is_a?(SequenceResult::Exists)
+              Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence adjustment enabled and #{name} not yet adjusted, adjusting now for #{klass.name}##{attribute}")
+              adjust_sequence_if_needed(name, klass, attribute, block)
+            end
+            sequence_cache[name] = SequenceResult::Exists.new(name)
 
-          result = ActiveRecord::Base.connection.execute(
-            "SELECT nextval('#{name}')",
-          )
-          result.first['nextval'].to_i
-        else
-          start_value = calculate_sequence_value(klass, attribute, block)
-
-          sequence_cache[name] = SequenceResult::Missing.new(
-            sequence_name: name,
-            klass: klass,
-            attribute: attribute,
-            calculated_start_value: start_value + 1,
-          )
-
-          if CleverSequence.enforce_sequences_exist
-            raise SequenceNotFoundError.new(
-              sequence_name: name,
-              klass: klass,
-              attribute: attribute,
+            result = ActiveRecord::Base.connection.execute(
+              "SELECT nextval('#{name}')",
             )
+            value = result.first['nextval'].to_i
+            Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] nextval for #{klass.name}##{attribute} returned #{value} from postgres sequence #{name}")
+            value
           else
-            start_value + 1
+            # Check if we already have this sequence cached as Missing
+            cached = sequence_cache[name]
+
+            if cached.is_a?(SequenceResult::Missing)
+              # Increment from cached value instead of recalculating from DB
+              # This handles the case where transactions are rolled back but we
+              # need to continue generating unique values
+              next_value = cached.calculated_start_value + 1
+              Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence #{name} missing (cached), incrementing from cached value #{cached.calculated_start_value} to #{next_value} for #{klass.name}##{attribute}")
+              sequence_cache[name] = SequenceResult::Missing.new(
+                sequence_name: name,
+                klass: klass,
+                attribute: attribute,
+                calculated_start_value: next_value,
+              )
+            else
+              # First time seeing this missing sequence - calculate from DB
+              start_value = calculate_sequence_value(klass, attribute, block)
+              next_value = start_value + 1
+              Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence #{name} missing (first encounter), calculated start_value=#{start_value}, returning next_value=#{next_value} for #{klass.name}##{attribute}")
+              sequence_cache[name] = SequenceResult::Missing.new(
+                sequence_name: name,
+                klass: klass,
+                attribute: attribute,
+                calculated_start_value: next_value,
+              )
+            end
+
+            if CleverSequence.enforce_sequences_exist
+              Rails.logger.warn("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Raising SequenceNotFoundError for #{klass.name}##{attribute} (sequence: #{name}, enforce_sequences_exist is enabled)")
+              raise SequenceNotFoundError.new(
+                sequence_name: name,
+                klass: klass,
+                attribute: attribute,
+              )
+            else
+              Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] nextval for #{klass.name}##{attribute} returning #{next_value} (fallback, sequence #{name} does not exist)")
+              next_value
+            end
           end
         end
       end
@@ -69,37 +115,79 @@ class CleverSequence
         attr = attribute.to_s.gsub(/[^a-z0-9_]/i, '_')
         # Handle PostgreSQL identifier limit:
         limit = (63 - SEQUENCE_PREFIX.length) / 2
-        "#{SEQUENCE_PREFIX}#{table[0, limit]}_#{attr[0, limit]}"
+        # Lowercase to avoid PostgreSQL case-sensitivity issues with unquoted identifiers
+        "#{SEQUENCE_PREFIX}#{table[0, limit]}_#{attr[0, limit]}".downcase
       end
 
       def sequence_cache
         @sequence_cache ||= {}
       end
 
+      def clear_sequence_cache!
+        @sequence_monitor.synchronize do
+          # Preserve Missing entries since those are needed for sequence discovery
+          # Only clear Exists entries so sequences get re-checked and potentially adjusted
+          existing_keys = sequence_cache.select { |_, v| v.is_a?(SequenceResult::Exists) }.keys
+          Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Clearing sequence cache: removing #{existing_keys.size} Exists entries (#{existing_keys.join(', ')}), preserving #{sequence_cache.size - existing_keys.size} Missing entries")
+          @sequence_cache = sequence_cache.select { |_, v| v.is_a?(SequenceResult::Missing) }
+        end
+      end
+
       private
+
+      def adjust_sequences_enabled?
+        Thread.current[:clever_sequence_adjust_sequences_enabled]
+      end
 
       def sequence_exists?(sequence_name)
         if sequence_cache.key?(sequence_name)
           case sequence_cache[sequence_name]
           when SequenceResult::Exists
+            Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence #{sequence_name} exists (cached)")
             return true
           else
+            Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence #{sequence_name} does not exist (cached as #{sequence_cache[sequence_name].class.name})")
             return false
           end
         end
 
-        ActiveRecord::Base.connection.execute(
+        exists = ActiveRecord::Base.connection.execute(
           "SELECT 1 FROM information_schema.sequences WHERE sequence_name = '#{sequence_name}' LIMIT 1",
         ).any?
+        Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence #{sequence_name} #{exists ? 'found' : 'not found'} in information_schema")
+        exists
       end
 
       def calculate_sequence_value(klass, attribute, block)
         column_name = klass.attribute_aliases.fetch(attribute.to_s, attribute.to_s)
-        return 0 unless klass.column_names.include?(column_name)
+        unless klass.column_names.include?(column_name)
+          Rails.logger.warn("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Column #{column_name} not found on #{klass.name}, returning 0 for sequence value calculation")
+          return 0
+        end
 
-        ActiveRecord::Base.with_transactional_lock("lower-bound-#{klass}-#{column_name}") do
+        value = ActiveRecord::Base.with_transactional_lock("lower-bound-#{klass}-#{column_name}") do
           LowerBoundFinder.new(klass, column_name, block).lower_bound
         end
+        Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Calculated sequence value for #{klass.name}##{attribute} (column: #{column_name}): #{value}")
+        value
+      end
+
+      def adjust_sequence_if_needed(sequence_name, klass, attribute, block)
+        max_value = calculate_sequence_value(klass, attribute, block)
+        if max_value < 1
+          Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] No adjustment needed for sequence #{sequence_name} (#{klass.name}##{attribute}), max_value=#{max_value}")
+          return
+        end
+
+        Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Adjusting sequence #{sequence_name} for #{klass.name}##{attribute} to at least #{max_value}")
+        # setval sets the sequence's last_value. With the default 3rd argument (true),
+        # the next nextval() will return last_value + 1.
+        # We only want to advance (never go backwards), so we use GREATEST.
+        result = ActiveRecord::Base.connection.execute(<<~SQL.squish)
+          SELECT setval('#{sequence_name}', GREATEST(#{max_value}, (SELECT last_value FROM #{sequence_name})))
+        SQL
+        new_last_value = result.first['setval'].to_i
+        Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence #{sequence_name} adjusted, new last_value=#{new_last_value} (next nextval will return #{new_last_value + 1})")
       end
     end
   end

--- a/lib/demo_mode/clever_sequence/postgres_backend.rb
+++ b/lib/demo_mode/clever_sequence/postgres_backend.rb
@@ -123,16 +123,6 @@ class CleverSequence
         @sequence_cache ||= {}
       end
 
-      def clear_sequence_cache!
-        @sequence_monitor.synchronize do
-          # Preserve Missing entries since those are needed for sequence discovery
-          # Only clear Exists entries so sequences get re-checked and potentially adjusted
-          existing_keys = sequence_cache.select { |_, v| v.is_a?(SequenceResult::Exists) }.keys
-          Rails.logger.info("[DemoMode] Clearing sequence cache: removing #{existing_keys.size} Exists entries (#{existing_keys.join(', ')}), preserving #{sequence_cache.size - existing_keys.size} Missing entries")
-          @sequence_cache = sequence_cache.select { |_, v| v.is_a?(SequenceResult::Missing) }
-        end
-      end
-
       private
 
       def adjust_sequences_enabled?

--- a/lib/demo_mode/clever_sequence/postgres_backend.rb
+++ b/lib/demo_mode/clever_sequence/postgres_backend.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-require 'monitor'
-
 class CleverSequence
   module PostgresBackend
     SEQUENCE_PREFIX = 'cs_'
+    SEQUENCE_CACHE_KEY = :clever_sequence_cache
 
     class SequenceNotFoundError < StandardError
       attr_reader :sequence_name, :klass, :attribute
@@ -25,13 +24,9 @@ class CleverSequence
       Missing = Data.define(:sequence_name, :klass, :attribute, :calculated_start_value)
     end
 
-    # Initialized eagerly at load time (single-threaded), so no race on creation.
-    # Monitor is reentrant, allowing nextval -> sequence_exists? nesting.
-    @sequence_monitor = Monitor.new
-
     class << self
       def reset!
-        @sequence_cache = {}
+        Thread.current[SEQUENCE_CACHE_KEY] = {}
       end
 
       def starting_value(klass, attribute, block)
@@ -48,15 +43,13 @@ class CleverSequence
       end
 
       def nextval(klass, attribute, block)
-        @sequence_monitor.synchronize do
-          name = sequence_name(klass, attribute)
-          log "[DemoMode] nextval called for #{klass.name}##{attribute} (sequence: #{name})"
+        name = sequence_name(klass, attribute)
+        log "[DemoMode] nextval called for #{klass.name}##{attribute} (sequence: #{name})"
 
-          if sequence_exists?(name)
-            nextval_from_sequence(name, klass, attribute, block)
-          else
-            nextval_without_sequence(name, klass, attribute, block)
-          end
+        if sequence_exists?(name)
+          nextval_from_sequence(name, klass, attribute, block)
+        else
+          nextval_without_sequence(name, klass, attribute, block)
         end
       end
 
@@ -70,7 +63,7 @@ class CleverSequence
       end
 
       def sequence_cache
-        @sequence_cache ||= {}
+        Thread.current[SEQUENCE_CACHE_KEY] ||= {}
       end
 
       private
@@ -160,22 +153,24 @@ class CleverSequence
       end
 
       def adjust_sequence_if_needed(sequence_name, klass, attribute, block)
-        max_value = calculate_sequence_value(klass, attribute, block)
-        if max_value < 1
-          log "[DemoMode] No adjustment needed for #{sequence_name}"
-          return
-        end
+        ActiveRecord::Base.with_transactional_lock("adjust-sequence-#{sequence_name}") do
+          max_value = calculate_sequence_value(klass, attribute, block)
+          if max_value < 1
+            log "[DemoMode] No adjustment needed for #{sequence_name}"
+            return
+          end
 
-        log "[DemoMode] Adjusting #{sequence_name} to at least #{max_value}"
-        # setval sets the sequence's last_value. With the default 3rd argument (true),
-        # the next nextval() will return last_value + 1.
-        # We only want to advance (never go backwards), so we use GREATEST.
-        result = ActiveRecord::Base.connection.execute(<<~SQL.squish)
-          SELECT setval('#{sequence_name}',
-            GREATEST(#{max_value}, (SELECT last_value FROM #{sequence_name})))
-        SQL
-        new_last_value = result.first['setval'].to_i
-        log "[DemoMode] #{sequence_name} adjusted to #{new_last_value}"
+          log "[DemoMode] Adjusting #{sequence_name} to at least #{max_value}"
+          # setval sets the sequence's last_value. With the default 3rd argument (true),
+          # the next nextval() will return last_value + 1.
+          # We only want to advance (never go backwards), so we use GREATEST.
+          result = ActiveRecord::Base.connection.execute(<<~SQL.squish)
+            SELECT setval('#{sequence_name}',
+              GREATEST(#{max_value}, (SELECT last_value FROM #{sequence_name})))
+          SQL
+          new_last_value = result.first['setval'].to_i
+          log "[DemoMode] #{sequence_name} adjusted to #{new_last_value}"
+        end
       end
     end
   end

--- a/lib/demo_mode/clever_sequence/postgres_backend.rb
+++ b/lib/demo_mode/clever_sequence/postgres_backend.rb
@@ -39,23 +39,23 @@ class CleverSequence
       end
 
       def with_sequence_adjustment
-        Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Enabling sequence adjustment for retry")
+        Rails.logger.info("[DemoMode] Enabling sequence adjustment for retry")
         Thread.current[:clever_sequence_adjust_sequences_enabled] = true
         yield
       ensure
         Thread.current[:clever_sequence_adjust_sequences_enabled] = false
-        Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Disabled sequence adjustment")
+        Rails.logger.info("[DemoMode] Disabled sequence adjustment")
       end
 
       def nextval(klass, attribute, block)
         @sequence_monitor.synchronize do
           name = sequence_name(klass, attribute)
-          Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] nextval called for #{klass.name}##{attribute} (sequence: #{name})")
+          Rails.logger.info("[DemoMode] nextval called for #{klass.name}##{attribute} (sequence: #{name})")
 
           if sequence_exists?(name)
             # On first use with adjustment enabled, ensure sequence is past existing data
             if adjust_sequences_enabled? && !sequence_cache[name].is_a?(SequenceResult::Exists)
-              Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence adjustment enabled and #{name} not yet adjusted, adjusting now for #{klass.name}##{attribute}")
+              Rails.logger.info("[DemoMode] Sequence adjustment enabled and #{name} not yet adjusted, adjusting now for #{klass.name}##{attribute}")
               adjust_sequence_if_needed(name, klass, attribute, block)
             end
             sequence_cache[name] = SequenceResult::Exists.new(name)
@@ -64,7 +64,7 @@ class CleverSequence
               "SELECT nextval('#{name}')",
             )
             value = result.first['nextval'].to_i
-            Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] nextval for #{klass.name}##{attribute} returned #{value} from postgres sequence #{name}")
+            Rails.logger.info("[DemoMode] nextval for #{klass.name}##{attribute} returned #{value} from postgres sequence #{name}")
             value
           else
             # Check if we already have this sequence cached as Missing
@@ -75,7 +75,7 @@ class CleverSequence
               # This handles the case where transactions are rolled back but we
               # need to continue generating unique values
               next_value = cached.calculated_start_value + 1
-              Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence #{name} missing (cached), incrementing from cached value #{cached.calculated_start_value} to #{next_value} for #{klass.name}##{attribute}")
+              Rails.logger.info("[DemoMode] Sequence #{name} missing (cached), incrementing from cached value #{cached.calculated_start_value} to #{next_value} for #{klass.name}##{attribute}")
               sequence_cache[name] = SequenceResult::Missing.new(
                 sequence_name: name,
                 klass: klass,
@@ -86,7 +86,7 @@ class CleverSequence
               # First time seeing this missing sequence - calculate from DB
               start_value = calculate_sequence_value(klass, attribute, block)
               next_value = start_value + 1
-              Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence #{name} missing (first encounter), calculated start_value=#{start_value}, returning next_value=#{next_value} for #{klass.name}##{attribute}")
+              Rails.logger.info("[DemoMode] Sequence #{name} missing (first encounter), calculated start_value=#{start_value}, returning next_value=#{next_value} for #{klass.name}##{attribute}")
               sequence_cache[name] = SequenceResult::Missing.new(
                 sequence_name: name,
                 klass: klass,
@@ -96,14 +96,14 @@ class CleverSequence
             end
 
             if CleverSequence.enforce_sequences_exist
-              Rails.logger.warn("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Raising SequenceNotFoundError for #{klass.name}##{attribute} (sequence: #{name}, enforce_sequences_exist is enabled)")
+              Rails.logger.warn("[DemoMode] Raising SequenceNotFoundError for #{klass.name}##{attribute} (sequence: #{name}, enforce_sequences_exist is enabled)")
               raise SequenceNotFoundError.new(
                 sequence_name: name,
                 klass: klass,
                 attribute: attribute,
               )
             else
-              Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] nextval for #{klass.name}##{attribute} returning #{next_value} (fallback, sequence #{name} does not exist)")
+              Rails.logger.info("[DemoMode] nextval for #{klass.name}##{attribute} returning #{next_value} (fallback, sequence #{name} does not exist)")
               next_value
             end
           end
@@ -128,7 +128,7 @@ class CleverSequence
           # Preserve Missing entries since those are needed for sequence discovery
           # Only clear Exists entries so sequences get re-checked and potentially adjusted
           existing_keys = sequence_cache.select { |_, v| v.is_a?(SequenceResult::Exists) }.keys
-          Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Clearing sequence cache: removing #{existing_keys.size} Exists entries (#{existing_keys.join(', ')}), preserving #{sequence_cache.size - existing_keys.size} Missing entries")
+          Rails.logger.info("[DemoMode] Clearing sequence cache: removing #{existing_keys.size} Exists entries (#{existing_keys.join(', ')}), preserving #{sequence_cache.size - existing_keys.size} Missing entries")
           @sequence_cache = sequence_cache.select { |_, v| v.is_a?(SequenceResult::Missing) }
         end
       end
@@ -143,10 +143,10 @@ class CleverSequence
         if sequence_cache.key?(sequence_name)
           case sequence_cache[sequence_name]
           when SequenceResult::Exists
-            Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence #{sequence_name} exists (cached)")
+            Rails.logger.info("[DemoMode] Sequence #{sequence_name} exists (cached)")
             return true
           else
-            Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence #{sequence_name} does not exist (cached as #{sequence_cache[sequence_name].class.name})")
+            Rails.logger.info("[DemoMode] Sequence #{sequence_name} does not exist (cached as #{sequence_cache[sequence_name].class.name})")
             return false
           end
         end
@@ -154,32 +154,32 @@ class CleverSequence
         exists = ActiveRecord::Base.connection.execute(
           "SELECT 1 FROM information_schema.sequences WHERE sequence_name = '#{sequence_name}' LIMIT 1",
         ).any?
-        Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence #{sequence_name} #{exists ? 'found' : 'not found'} in information_schema")
+        Rails.logger.info("[DemoMode] Sequence #{sequence_name} #{exists ? 'found' : 'not found'} in information_schema")
         exists
       end
 
       def calculate_sequence_value(klass, attribute, block)
         column_name = klass.attribute_aliases.fetch(attribute.to_s, attribute.to_s)
         unless klass.column_names.include?(column_name)
-          Rails.logger.warn("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Column #{column_name} not found on #{klass.name}, returning 0 for sequence value calculation")
+          Rails.logger.warn("[DemoMode] Column #{column_name} not found on #{klass.name}, returning 0 for sequence value calculation")
           return 0
         end
 
         value = ActiveRecord::Base.with_transactional_lock("lower-bound-#{klass}-#{column_name}") do
           LowerBoundFinder.new(klass, column_name, block).lower_bound
         end
-        Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Calculated sequence value for #{klass.name}##{attribute} (column: #{column_name}): #{value}")
+        Rails.logger.info("[DemoMode] Calculated sequence value for #{klass.name}##{attribute} (column: #{column_name}): #{value}")
         value
       end
 
       def adjust_sequence_if_needed(sequence_name, klass, attribute, block)
         max_value = calculate_sequence_value(klass, attribute, block)
         if max_value < 1
-          Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] No adjustment needed for sequence #{sequence_name} (#{klass.name}##{attribute}), max_value=#{max_value}")
+          Rails.logger.info("[DemoMode] No adjustment needed for sequence #{sequence_name} (#{klass.name}##{attribute}), max_value=#{max_value}")
           return
         end
 
-        Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Adjusting sequence #{sequence_name} for #{klass.name}##{attribute} to at least #{max_value}")
+        Rails.logger.info("[DemoMode] Adjusting sequence #{sequence_name} for #{klass.name}##{attribute} to at least #{max_value}")
         # setval sets the sequence's last_value. With the default 3rd argument (true),
         # the next nextval() will return last_value + 1.
         # We only want to advance (never go backwards), so we use GREATEST.
@@ -187,7 +187,7 @@ class CleverSequence
           SELECT setval('#{sequence_name}', GREATEST(#{max_value}, (SELECT last_value FROM #{sequence_name})))
         SQL
         new_last_value = result.first['setval'].to_i
-        Rails.logger.info("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Sequence #{sequence_name} adjusted, new last_value=#{new_last_value} (next nextval will return #{new_last_value + 1})")
+        Rails.logger.info("[DemoMode] Sequence #{sequence_name} adjusted, new last_value=#{new_last_value} (next nextval will return #{new_last_value + 1})")
       end
     end
   end

--- a/lib/demo_mode/clever_sequence/postgres_backend.rb
+++ b/lib/demo_mode/clever_sequence/postgres_backend.rb
@@ -35,14 +35,14 @@ class CleverSequence
       def with_sequence_adjustment(last_values: {})
         previous = Thread.current[:clever_sequence_adjustment_enabled]
         previous_last_values = Thread.current[:clever_sequence_last_values]
-        Rails.logger.info("[DemoMode] Enabling sequence adjustment for retry")
+        log "[DemoMode] Enabling sequence adjustment for retry"
         Thread.current[:clever_sequence_adjustment_enabled] = true
         Thread.current[:clever_sequence_last_values] = last_values
         yield
       ensure
         Thread.current[:clever_sequence_adjustment_enabled] = previous
         Thread.current[:clever_sequence_last_values] = previous_last_values
-        Rails.logger.info("[DemoMode] Disabled sequence adjustment")
+        log "[DemoMode] Disabled sequence adjustment"
       end
 
       def nextval(klass, attribute, block)
@@ -71,7 +71,7 @@ class CleverSequence
 
       private
 
-      def log(message, level: :info)
+      def log(message, level: DemoMode.log_level)
         Rails.logger.public_send(level, message)
       end
 

--- a/lib/demo_mode/config.rb
+++ b/lib/demo_mode/config.rb
@@ -13,6 +13,7 @@ module DemoMode
     configurable_value(:signinable_username_method) { :email }
     configurable_value(:personas_path) { 'config/personas' }
     configurable_value(:session_timeout) { 30.minutes }
+    configurable_value(:log_level) { :debug }
     configurable_boolean(:display_credentials)
     configurations << :stylesheets
     configurations << :logo

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -63,14 +63,29 @@ module DemoMode
     end
 
     def generate!(variant: :default, password: nil, options: {})
+      retried = false
       ActiveSupport::Notifications.instrument('demo_mode.persona.generate', name: name, variant: variant) do
         variant = variants[variant]
         CleverSequence.reset! if defined?(CleverSequence)
         DemoMode.current_password = password if password
         DemoMode.around_persona_generation.call(variant.signinable_generator, **options)
+      rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+        raise if retried || !should_retry_with_sequence_adjustment?(e)
+
+        retried = true
+        CleverSequence.with_sequence_adjustment do
+          DemoMode.around_persona_generation.call(variant.signinable_generator, **options)
+        end
       ensure
         DemoMode.current_password = nil
       end
+    end
+
+    def should_retry_with_sequence_adjustment?(error)
+      return false unless defined?(CleverSequence)
+
+      Rails.logger.warn("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Uniqueness violation during persona generation, retrying with sequence adjustment: #{error.message}")
+      true
     end
 
     def callout(callout = true) # rubocop:disable Style/OptionalBooleanParameter

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -83,6 +83,7 @@ module DemoMode
 
     def should_retry_with_sequence_adjustment?(error)
       return false unless defined?(CleverSequence)
+      return false unless CleverSequence.retry_on_uniqueness_violation?
 
       Rails.logger.warn("[DemoMode] Uniqueness violation during persona generation, retrying with sequence adjustment: #{error.message}")
       true

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -84,7 +84,7 @@ module DemoMode
     def should_retry_with_sequence_adjustment?(error)
       return false unless defined?(CleverSequence)
 
-      Rails.logger.warn("[DemoMode][thread:#{Thread.current.name || Thread.current.object_id}] Uniqueness violation during persona generation, retrying with sequence adjustment: #{error.message}")
+      Rails.logger.warn("[DemoMode] Uniqueness violation during persona generation, retrying with sequence adjustment: #{error.message}")
       true
     end
 

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '3.5.0'
+  VERSION = '3.6.0'
 end

--- a/spec/clever_sequence/in_memory_backend_spec.rb
+++ b/spec/clever_sequence/in_memory_backend_spec.rb
@@ -87,6 +87,19 @@ RSpec.describe CleverSequence::InMemoryBackend do
     end
   end
 
+  describe '.with_sequence_adjustment' do
+    it 'yields without modification' do
+      executed = false
+      described_class.with_sequence_adjustment { executed = true }
+      expect(executed).to be true
+    end
+
+    it 'returns the block value' do
+      result = described_class.with_sequence_adjustment { 42 }
+      expect(result).to eq 42
+    end
+  end
+
   describe '.reset!' do
     it 'clears all sequence state so values re-derive from the database' do
       described_class.nextval(klass, :integer_column, block)

--- a/spec/clever_sequence/lower_bound_finder_spec.rb
+++ b/spec/clever_sequence/lower_bound_finder_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe CleverSequence::LowerBoundFinder do
     context 'on non-PostgreSQL adapters' do
       before { allow(ActiveRecord::Base.connection).to receive(:adapter_name).and_return('SQLite') }
 
-      it 'does not use with_transactional_lock' do
+      it 'skips locking and runs without a lock' do
         expect(ActiveRecord::Base).not_to receive(:with_transactional_lock)
         expect(finder.lower_bound).to eq 0
       end

--- a/spec/clever_sequence/lower_bound_finder_spec.rb
+++ b/spec/clever_sequence/lower_bound_finder_spec.rb
@@ -89,12 +89,10 @@ RSpec.describe CleverSequence::LowerBoundFinder do
         expect(finder.lower_bound(hint: 3)).to eq 3
       end
 
-      it 'still finds the correct bound when hint overshoots' do
+      it 'returns the hint directly when it overshoots actual data' do
         allow(klass).to receive(:find_by_integer_column).and_return(nil)
-        allow(klass).to receive(:find_by_integer_column).with(1).and_return(true)
-        allow(klass).to receive(:find_by_integer_column).with(2).and_return(true)
 
-        expect(finder.lower_bound(hint: 50)).to eq 2
+        expect(finder.lower_bound(hint: 50)).to eq 50
       end
 
       it 'ignores hint when nil' do

--- a/spec/clever_sequence/lower_bound_finder_spec.rb
+++ b/spec/clever_sequence/lower_bound_finder_spec.rb
@@ -69,6 +69,53 @@ RSpec.describe CleverSequence::LowerBoundFinder do
       # Binary search should find this in O(log n) queries, not 1000
       expect(klass).to have_received(:find_by_integer_column).at_most(25).times
     end
+
+    context 'with a hint' do
+      it 'starts the search from the hint value' do
+        existing_records = (1..1000).to_a
+        allow(klass).to receive(:find_by_integer_column) do |val|
+          existing_records.include?(val)
+        end
+
+        expect(finder.lower_bound(hint: 990)).to eq 1000
+
+        # With a hint of 990, the search should converge much faster
+        # than starting from 1 (which would take ~20 queries)
+        expect(klass).to have_received(:find_by_integer_column).at_most(15).times
+      end
+
+      it 'still finds the correct bound when hint is exact' do
+        allow(klass).to receive(:find_by_integer_column).and_return(nil)
+        allow(klass).to receive(:find_by_integer_column).with(1).and_return(true)
+        allow(klass).to receive(:find_by_integer_column).with(2).and_return(true)
+        allow(klass).to receive(:find_by_integer_column).with(3).and_return(true)
+
+        expect(finder.lower_bound(hint: 3)).to eq 3
+      end
+
+      it 'still finds the correct bound when hint overshoots' do
+        allow(klass).to receive(:find_by_integer_column).and_return(nil)
+        allow(klass).to receive(:find_by_integer_column).with(1).and_return(true)
+        allow(klass).to receive(:find_by_integer_column).with(2).and_return(true)
+
+        expect(finder.lower_bound(hint: 50)).to eq 2
+      end
+
+      it 'ignores hint when nil' do
+        allow(klass).to receive(:find_by_integer_column).and_return(nil)
+        allow(klass).to receive(:find_by_integer_column).with(1).and_return(true)
+
+        expect(finder.lower_bound(hint: nil)).to eq 1
+      end
+
+      it 'ignores hint when less than 1' do
+        allow(klass).to receive(:find_by_integer_column).and_return(nil)
+        allow(klass).to receive(:find_by_integer_column).with(1).and_return(true)
+
+        expect(finder.lower_bound(hint: 0)).to eq 1
+        expect(finder.lower_bound(hint: -5)).to eq 1
+      end
+    end
   end
 
   describe '#next_between' do

--- a/spec/clever_sequence/lower_bound_finder_spec.rb
+++ b/spec/clever_sequence/lower_bound_finder_spec.rb
@@ -112,6 +112,38 @@ RSpec.describe CleverSequence::LowerBoundFinder do
     end
   end
 
+  describe 'locking' do
+    it 'acquires a transactional lock keyed to klass and column_name' do
+      allow(klass).to receive(:find_by_integer_column).and_return(nil)
+
+      expect(ActiveRecord::Base).to receive(:with_transactional_lock)
+        .with("lower-bound-#{klass}-integer_column")
+        .and_yield
+
+      finder.lower_bound
+    end
+
+    it 'performs the binary search inside the lock' do
+      lock_active = false
+      search_ran_inside_lock = false
+
+      allow(ActiveRecord::Base).to receive(:with_transactional_lock) do |_key, &blk|
+        lock_active = true
+        blk.call
+      ensure
+        lock_active = false
+      end
+
+      allow(klass).to receive(:find_by_integer_column) do
+        search_ran_inside_lock = true if lock_active
+        nil
+      end
+
+      finder.lower_bound
+      expect(search_ran_inside_lock).to be true
+    end
+  end
+
   describe '#next_between' do
     it 'calculates next search point using formula [((lower+1)/2)+(upper/2), lower*2].min' do
       # For lower=10, upper=100: min((5 + 50), 20) = 20

--- a/spec/clever_sequence/lower_bound_finder_spec.rb
+++ b/spec/clever_sequence/lower_bound_finder_spec.rb
@@ -43,8 +43,7 @@ RSpec.describe CleverSequence::LowerBoundFinder do
 
       expect(finder.lower_bound).to eq 100
 
-      # Verify it used binary search (should be O(log n) calls, not 100)
-      expect(klass).to have_received(:find_by_integer_column).at_most(20).times
+      expect(klass).to have_received(:find_by_integer_column).exactly(14).times
     end
 
     it 'finds consecutive records and returns highest existing value' do
@@ -66,8 +65,7 @@ RSpec.describe CleverSequence::LowerBoundFinder do
 
       expect(finder.lower_bound).to eq 1000
 
-      # Binary search should find this in O(log n) queries, not 1000
-      expect(klass).to have_received(:find_by_integer_column).at_most(25).times
+      expect(klass).to have_received(:find_by_integer_column).exactly(20).times
     end
 
     context 'with a hint' do
@@ -79,9 +77,7 @@ RSpec.describe CleverSequence::LowerBoundFinder do
 
         expect(finder.lower_bound(hint: 990)).to eq 1000
 
-        # With a hint of 990, the search should converge much faster
-        # than starting from 1 (which would take ~20 queries)
-        expect(klass).to have_received(:find_by_integer_column).at_most(15).times
+        expect(klass).to have_received(:find_by_integer_column).exactly(13).times
       end
 
       it 'still finds the correct bound when hint is exact' do

--- a/spec/clever_sequence/lower_bound_finder_spec.rb
+++ b/spec/clever_sequence/lower_bound_finder_spec.rb
@@ -113,34 +113,27 @@ RSpec.describe CleverSequence::LowerBoundFinder do
   end
 
   describe 'locking' do
-    it 'acquires a transactional lock keyed to klass and column_name' do
-      allow(klass).to receive(:find_by_integer_column).and_return(nil)
+    before { allow(klass).to receive(:find_by_integer_column).and_return(nil) }
 
-      expect(ActiveRecord::Base).to receive(:with_transactional_lock)
-        .with("lower-bound-#{klass}-integer_column")
-        .and_yield
+    context 'on PostgreSQL' do
+      before { allow(ActiveRecord::Base.connection).to receive(:adapter_name).and_return('PostgreSQL') }
 
-      finder.lower_bound
+      it 'acquires a transactional lock keyed to klass and column_name' do
+        expect(ActiveRecord::Base).to receive(:with_transactional_lock)
+          .with("lower-bound-#{klass}-integer_column")
+          .and_yield
+
+        finder.lower_bound
+      end
     end
 
-    it 'performs the binary search inside the lock' do
-      lock_active = false
-      search_ran_inside_lock = false
+    context 'on non-PostgreSQL adapters' do
+      before { allow(ActiveRecord::Base.connection).to receive(:adapter_name).and_return('SQLite') }
 
-      allow(ActiveRecord::Base).to receive(:with_transactional_lock) do |_key, &blk|
-        lock_active = true
-        blk.call
-      ensure
-        lock_active = false
+      it 'does not use with_transactional_lock' do
+        expect(ActiveRecord::Base).not_to receive(:with_transactional_lock)
+        expect(finder.lower_bound).to eq 0
       end
-
-      allow(klass).to receive(:find_by_integer_column) do
-        search_ran_inside_lock = true if lock_active
-        nil
-      end
-
-      finder.lower_bound
-      expect(search_ran_inside_lock).to be true
     end
   end
 

--- a/spec/clever_sequence/postgres_backend_spec.rb
+++ b/spec/clever_sequence/postgres_backend_spec.rb
@@ -68,6 +68,104 @@ RSpec.describe CleverSequence::PostgresBackend do
       expect(cached).to be_a(CleverSequence::PostgresBackend::SequenceResult::Exists)
       expect(cached.sequence_name).to eq sequence_name
     end
+
+    context 'when existing data conflicts with sequence start value' do
+      before do
+        described_class.reset!
+        # Create widgets with integer_column values 1, 2, 3, 4, 5
+        (1..5).each { |i| Widget.create!(integer_column: i) }
+      end
+
+      after do
+        Widget.delete_all
+      end
+
+      context 'without sequence adjustment' do
+        it 'does not adjust sequence and returns conflicting values' do
+          # Without adjustment, sequence returns 1, 2, 3... which conflict
+          result = described_class.nextval(klass, attribute, block)
+          expect(result).to eq 1
+        end
+      end
+
+      context 'with sequence adjustment' do
+        it 'adjusts sequence to skip past existing values' do
+          described_class.with_sequence_adjustment do
+            # Sequence starts at 1, but values 1-5 already exist
+            # First nextval should return 6 (after adjustment)
+            result = described_class.nextval(klass, attribute, block)
+            expect(result).to eq 6
+          end
+        end
+
+        it 'returns sequential values after adjustment' do
+          described_class.with_sequence_adjustment do
+            result_1 = described_class.nextval(klass, attribute, block)
+            result_2 = described_class.nextval(klass, attribute, block)
+            result_3 = described_class.nextval(klass, attribute, block)
+
+            expect(result_1).to eq 6
+            expect(result_2).to eq 7
+            expect(result_3).to eq 8
+          end
+        end
+
+        it 'only adjusts sequence on first use' do
+          execute_calls = []
+          allow(ActiveRecord::Base.connection).to receive(:execute).and_wrap_original do |method, *args|
+            execute_calls << args[0]
+            method.call(*args)
+          end
+
+          described_class.with_sequence_adjustment do
+            described_class.nextval(klass, attribute, block)
+            described_class.nextval(klass, attribute, block)
+            described_class.nextval(klass, attribute, block)
+          end
+
+          setval_queries = execute_calls.grep(/setval/)
+          expect(setval_queries.count).to eq 1
+        end
+      end
+    end
+
+    context 'when sequence is already past existing data' do
+      before do
+        described_class.reset!
+        # Create widgets with low values
+        Widget.create!(integer_column: 1)
+        Widget.create!(integer_column: 2)
+        # Advance the sequence past existing data
+        ActiveRecord::Base.connection.execute(
+          "SELECT setval('#{sequence_name}', 100)",
+        )
+      end
+
+      after do
+        Widget.delete_all
+      end
+
+      it 'does not go backwards' do
+        described_class.with_sequence_adjustment do
+          # Sequence is at 100, existing data only goes to 2
+          # Should return 101, not 3
+          result = described_class.nextval(klass, attribute, block)
+          expect(result).to eq 101
+        end
+      end
+    end
+
+    context 'when no existing data' do
+      before do
+        described_class.reset!
+        Widget.delete_all
+      end
+
+      it 'returns values starting from 1' do
+        result = described_class.nextval(klass, attribute, block)
+        expect(result).to eq 1
+      end
+    end
   end
 
   context 'when sequence does not exist' do
@@ -152,6 +250,123 @@ RSpec.describe CleverSequence::PostgresBackend do
       described_class.sequence_cache['some_key'] = 'value'
       described_class.reset!
       expect(described_class.sequence_cache).to be_empty
+    end
+  end
+
+  describe '.clear_sequence_cache!' do
+    let(:sequence_name) { described_class.sequence_name(klass, attribute) }
+
+    before do
+      ActiveRecord::Base.connection.execute(
+        "CREATE SEQUENCE IF NOT EXISTS #{sequence_name} START WITH 1",
+      )
+      described_class.reset!
+    end
+
+    after do
+      ActiveRecord::Base.connection.execute(
+        "DROP SEQUENCE IF EXISTS #{sequence_name}",
+      )
+    end
+
+    it 'clears Exists entries from the sequence cache' do
+      # Populate the cache with an Exists entry
+      described_class.nextval(klass, attribute, block)
+      expect(described_class.sequence_cache).not_to be_empty
+
+      described_class.clear_sequence_cache!
+      expect(described_class.sequence_cache).to be_empty
+    end
+
+    it 'allows adjustment to run again after clearing' do
+      Widget.create!(integer_column: 1)
+
+      described_class.with_sequence_adjustment do
+        # First call adjusts the sequence (finds max consecutive value of 1)
+        result_1 = described_class.nextval(klass, attribute, block)
+        expect(result_1).to eq 2
+
+        # Add more consecutive data (2, 3, 4, 5)
+        (2..5).each { |i| Widget.create!(integer_column: i) }
+
+        # Without clearing, adjustment doesn't run again
+        result_2 = described_class.nextval(klass, attribute, block)
+        expect(result_2).to eq 3
+
+        # Clear cache and reset sequence to simulate retry
+        described_class.clear_sequence_cache!
+        ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{sequence_name} RESTART WITH 1")
+
+        # Now adjustment runs again and finds max consecutive value of 5
+        result_3 = described_class.nextval(klass, attribute, block)
+        expect(result_3).to eq 6
+      end
+    ensure
+      Widget.delete_all
+    end
+  end
+
+  describe 'thread safety' do
+    let(:sequence_name) { described_class.sequence_name(klass, :nonexistent_column) }
+    let(:nonexistent_attribute) { :nonexistent_column }
+
+    before do
+      ActiveRecord::Base.connection.execute(
+        "DROP SEQUENCE IF EXISTS #{sequence_name}",
+      )
+      described_class.reset!
+      CleverSequence.enforce_sequences_exist = false
+    end
+
+    after do
+      CleverSequence.enforce_sequences_exist = false
+    end
+
+    it 'returns unique values when nextval is called concurrently from multiple threads' do
+      thread_count = 10
+
+      # Seed the cache with a Missing entry so all threads exercise the
+      # cached read-increment-write path without needing DB connections.
+      described_class.nextval(klass, nonexistent_attribute, block)
+
+      go = false
+
+      threads = thread_count.times.map do
+        Thread.new do
+          Thread.pass until go
+          described_class.nextval(klass, nonexistent_attribute, block)
+        end
+      end
+
+      go = true
+
+      values = threads.map(&:value)
+
+      expect(values).to all(be_an(Integer))
+      expect(values.uniq.size).to eq(thread_count),
+        "Expected #{thread_count} unique values but got duplicates: #{values.sort}"
+    end
+  end
+
+  describe '.with_sequence_adjustment' do
+    it 'enables adjustment within the block' do
+      enabled_inside = nil
+      described_class.with_sequence_adjustment do
+        enabled_inside = Thread.current[:clever_sequence_adjust_sequences_enabled]
+      end
+      expect(enabled_inside).to be true
+    end
+
+    it 'disables adjustment after the block' do
+      described_class.with_sequence_adjustment { nil }
+      expect(Thread.current[:clever_sequence_adjust_sequences_enabled]).to be false
+    end
+
+    it 'disables adjustment even if the block raises' do
+      expect {
+        described_class.with_sequence_adjustment { raise 'oops' }
+      }.to raise_error('oops')
+      expect(Thread.current[:clever_sequence_adjust_sequences_enabled]).to be false
     end
   end
 

--- a/spec/clever_sequence/postgres_backend_spec.rb
+++ b/spec/clever_sequence/postgres_backend_spec.rb
@@ -146,31 +146,6 @@ RSpec.describe CleverSequence::PostgresBackend do
 
           expect(hint_received).to eq 4
         end
-
-        it 'uses fewer queries with a good hint' do
-          # Create 100 records to make the difference between hinted and unhinted measurable
-          Widget.delete_all
-          (1..100).each { |i| Widget.create!(integer_column: i) }
-
-          # Reset the sequence to 1 so adjustment is needed
-          ActiveRecord::Base.connection.execute(
-            "SELECT setval('#{sequence_name}', 1, false)",
-          )
-
-          finder_calls = 0
-          allow(klass).to receive(:find_by_integer_column).and_wrap_original do |method, *args|
-            finder_calls += 1
-            method.call(*args)
-          end
-
-          described_class.with_sequence_adjustment(last_values: { %w(Widget integer_column) => 95 }) do
-            described_class.nextval(klass, attribute, block)
-          end
-
-          # With a hint of 95 (close to actual max of 100), the binary search
-          # should converge much faster than the ~14 queries needed from 1
-          expect(finder_calls).to be <= 10
-        end
       end
     end
 

--- a/spec/clever_sequence/postgres_backend_spec.rb
+++ b/spec/clever_sequence/postgres_backend_spec.rb
@@ -253,59 +253,6 @@ RSpec.describe CleverSequence::PostgresBackend do
     end
   end
 
-  describe '.clear_sequence_cache!' do
-    let(:sequence_name) { described_class.sequence_name(klass, attribute) }
-
-    before do
-      ActiveRecord::Base.connection.execute(
-        "CREATE SEQUENCE IF NOT EXISTS #{sequence_name} START WITH 1",
-      )
-      described_class.reset!
-    end
-
-    after do
-      ActiveRecord::Base.connection.execute(
-        "DROP SEQUENCE IF EXISTS #{sequence_name}",
-      )
-    end
-
-    it 'clears Exists entries from the sequence cache' do
-      # Populate the cache with an Exists entry
-      described_class.nextval(klass, attribute, block)
-      expect(described_class.sequence_cache).not_to be_empty
-
-      described_class.clear_sequence_cache!
-      expect(described_class.sequence_cache).to be_empty
-    end
-
-    it 'allows adjustment to run again after clearing' do
-      Widget.create!(integer_column: 1)
-
-      described_class.with_sequence_adjustment do
-        # First call adjusts the sequence (finds max consecutive value of 1)
-        result_1 = described_class.nextval(klass, attribute, block)
-        expect(result_1).to eq 2
-
-        # Add more consecutive data (2, 3, 4, 5)
-        (2..5).each { |i| Widget.create!(integer_column: i) }
-
-        # Without clearing, adjustment doesn't run again
-        result_2 = described_class.nextval(klass, attribute, block)
-        expect(result_2).to eq 3
-
-        # Clear cache and reset sequence to simulate retry
-        described_class.clear_sequence_cache!
-        ActiveRecord::Base.connection.execute("ALTER SEQUENCE #{sequence_name} RESTART WITH 1")
-
-        # Now adjustment runs again and finds max consecutive value of 5
-        result_3 = described_class.nextval(klass, attribute, block)
-        expect(result_3).to eq 6
-      end
-    ensure
-      Widget.delete_all
-    end
-  end
-
   describe 'thread safety' do
     let(:sequence_name) { described_class.sequence_name(klass, :nonexistent_column) }
     let(:nonexistent_attribute) { :nonexistent_column }

--- a/spec/clever_sequence/postgres_backend_spec.rb
+++ b/spec/clever_sequence/postgres_backend_spec.rb
@@ -126,6 +126,51 @@ RSpec.describe CleverSequence::PostgresBackend do
           setval_queries = execute_calls.grep(/setval/)
           expect(setval_queries.count).to eq 1
         end
+
+        it 'passes hint to LowerBoundFinder when last_values are provided' do
+          last_values = { %w(Widget integer_column) => 4 }
+          hint_received = nil
+
+          allow(CleverSequence::LowerBoundFinder).to receive(:new).and_wrap_original do |method, *args|
+            method.call(*args).tap do |finder|
+              allow(finder).to receive(:lower_bound).and_wrap_original do |m, **kwargs|
+                hint_received = kwargs[:hint]
+                m.call(**kwargs)
+              end
+            end
+          end
+
+          described_class.with_sequence_adjustment(last_values:) do
+            described_class.nextval(klass, attribute, block)
+          end
+
+          expect(hint_received).to eq 4
+        end
+
+        it 'uses fewer queries with a good hint' do
+          # Create 100 records to make the difference between hinted and unhinted measurable
+          Widget.delete_all
+          (1..100).each { |i| Widget.create!(integer_column: i) }
+
+          # Reset the sequence to 1 so adjustment is needed
+          ActiveRecord::Base.connection.execute(
+            "SELECT setval('#{sequence_name}', 1, false)",
+          )
+
+          finder_calls = 0
+          allow(klass).to receive(:find_by_integer_column).and_wrap_original do |method, *args|
+            finder_calls += 1
+            method.call(*args)
+          end
+
+          described_class.with_sequence_adjustment(last_values: { %w(Widget integer_column) => 95 }) do
+            described_class.nextval(klass, attribute, block)
+          end
+
+          # With a hint of 95 (close to actual max of 100), the binary search
+          # should converge much faster than the ~14 queries needed from 1
+          expect(finder_calls).to be <= 10
+        end
       end
     end
 
@@ -269,21 +314,40 @@ RSpec.describe CleverSequence::PostgresBackend do
     it 'enables adjustment within the block' do
       enabled_inside = nil
       described_class.with_sequence_adjustment do
-        enabled_inside = Thread.current[:clever_sequence_adjust_sequences_enabled]
+        enabled_inside = Thread.current[CleverSequence::PostgresBackend::ADJUSTMENT_ENABLED_KEY]
       end
       expect(enabled_inside).to be true
     end
 
     it 'disables adjustment after the block' do
       described_class.with_sequence_adjustment { nil }
-      expect(Thread.current[:clever_sequence_adjust_sequences_enabled]).to be false
+      expect(Thread.current[CleverSequence::PostgresBackend::ADJUSTMENT_ENABLED_KEY]).to be_falsey
     end
 
     it 'disables adjustment even if the block raises' do
       expect {
         described_class.with_sequence_adjustment { raise 'oops' }
       }.to raise_error('oops')
-      expect(Thread.current[:clever_sequence_adjust_sequences_enabled]).to be false
+      expect(Thread.current[CleverSequence::PostgresBackend::ADJUSTMENT_ENABLED_KEY]).to be_falsey
+    end
+
+    it 'stores last_values in thread-local and cleans up after' do
+      last_values = { %w(Widget integer_column) => 42 }
+      stored_inside = nil
+
+      described_class.with_sequence_adjustment(last_values:) do
+        stored_inside = Thread.current[CleverSequence::PostgresBackend::LAST_VALUES_KEY]
+      end
+
+      expect(stored_inside).to eq(last_values)
+      expect(Thread.current[CleverSequence::PostgresBackend::LAST_VALUES_KEY]).to be_nil
+    end
+
+    it 'cleans up last_values even if the block raises' do
+      expect {
+        described_class.with_sequence_adjustment(last_values: { foo: 1 }) { raise 'oops' }
+      }.to raise_error('oops')
+      expect(Thread.current[CleverSequence::PostgresBackend::LAST_VALUES_KEY]).to be_nil
     end
   end
 

--- a/spec/clever_sequence/postgres_backend_spec.rb
+++ b/spec/clever_sequence/postgres_backend_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe CleverSequence::PostgresBackend do
 
       go = false
 
-      threads = thread_count.times.map do
+      threads = Array.new(thread_count) do
         Thread.new do
           Thread.pass until go
           described_class.nextval(klass, nonexistent_attribute, block)

--- a/spec/clever_sequence/postgres_backend_spec.rb
+++ b/spec/clever_sequence/postgres_backend_spec.rb
@@ -289,21 +289,21 @@ RSpec.describe CleverSequence::PostgresBackend do
     it 'enables adjustment within the block' do
       enabled_inside = nil
       described_class.with_sequence_adjustment do
-        enabled_inside = Thread.current[CleverSequence::PostgresBackend::ADJUSTMENT_ENABLED_KEY]
+        enabled_inside = Thread.current[:clever_sequence_adjustment_enabled]
       end
       expect(enabled_inside).to be true
     end
 
     it 'disables adjustment after the block' do
       described_class.with_sequence_adjustment { nil }
-      expect(Thread.current[CleverSequence::PostgresBackend::ADJUSTMENT_ENABLED_KEY]).to be_falsey
+      expect(Thread.current[:clever_sequence_adjustment_enabled]).to be_falsey
     end
 
     it 'disables adjustment even if the block raises' do
       expect {
         described_class.with_sequence_adjustment { raise 'oops' }
       }.to raise_error('oops')
-      expect(Thread.current[CleverSequence::PostgresBackend::ADJUSTMENT_ENABLED_KEY]).to be_falsey
+      expect(Thread.current[:clever_sequence_adjustment_enabled]).to be_falsey
     end
 
     it 'stores last_values in thread-local and cleans up after' do
@@ -311,18 +311,18 @@ RSpec.describe CleverSequence::PostgresBackend do
       stored_inside = nil
 
       described_class.with_sequence_adjustment(last_values:) do
-        stored_inside = Thread.current[CleverSequence::PostgresBackend::LAST_VALUES_KEY]
+        stored_inside = Thread.current[:clever_sequence_last_values]
       end
 
       expect(stored_inside).to eq(last_values)
-      expect(Thread.current[CleverSequence::PostgresBackend::LAST_VALUES_KEY]).to be_nil
+      expect(Thread.current[:clever_sequence_last_values]).to be_nil
     end
 
     it 'cleans up last_values even if the block raises' do
       expect {
         described_class.with_sequence_adjustment(last_values: { foo: 1 }) { raise 'oops' }
       }.to raise_error('oops')
-      expect(Thread.current[CleverSequence::PostgresBackend::LAST_VALUES_KEY]).to be_nil
+      expect(Thread.current[:clever_sequence_last_values]).to be_nil
     end
   end
 

--- a/spec/clever_sequence/postgres_backend_spec.rb
+++ b/spec/clever_sequence/postgres_backend_spec.rb
@@ -254,44 +254,14 @@ RSpec.describe CleverSequence::PostgresBackend do
   end
 
   describe 'thread safety' do
-    let(:sequence_name) { described_class.sequence_name(klass, :nonexistent_column) }
-    let(:nonexistent_attribute) { :nonexistent_column }
-
-    before do
-      ActiveRecord::Base.connection.execute(
-        "DROP SEQUENCE IF EXISTS #{sequence_name}",
-      )
+    it 'uses thread-local sequence caches' do
       described_class.reset!
-      CleverSequence.enforce_sequences_exist = false
-    end
+      described_class.sequence_cache['test_key'] = 'main_thread_value'
 
-    after do
-      CleverSequence.enforce_sequences_exist = false
-    end
+      thread_cache = Thread.new { described_class.sequence_cache }.value
 
-    it 'returns unique values when nextval is called concurrently from multiple threads' do
-      thread_count = 10
-
-      # Seed the cache with a Missing entry so all threads exercise the
-      # cached read-increment-write path without needing DB connections.
-      described_class.nextval(klass, nonexistent_attribute, block)
-
-      go = false
-
-      threads = Array.new(thread_count) do
-        Thread.new do
-          Thread.pass until go
-          described_class.nextval(klass, nonexistent_attribute, block)
-        end
-      end
-
-      go = true
-
-      values = threads.map(&:value)
-
-      expect(values).to all(be_an(Integer))
-      expect(values.uniq.size).to eq(thread_count),
-        "Expected #{thread_count} unique values but got duplicates: #{values.sort}"
+      expect(thread_cache).to be_empty
+      expect(described_class.sequence_cache['test_key']).to eq('main_thread_value')
     end
   end
 

--- a/spec/clever_sequence_spec.rb
+++ b/spec/clever_sequence_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe CleverSequence do
       end
 
       it 'produces unique values under concurrent access' do
-        threads = 20.times.map { Thread.new { subject.next } }
+        threads = Array.new(20) { Thread.new { subject.next } }
         values = threads.map(&:value)
         expect(values.uniq.length).to eq 20
       end

--- a/spec/clever_sequence_spec.rb
+++ b/spec/clever_sequence_spec.rb
@@ -114,24 +114,24 @@ RSpec.describe CleverSequence do
     end
   end
 
-  describe '#last_value_if_set' do
+  describe '#last_value' do
     let(:attribute) { :integer_column }
 
     it 'returns nil when no value has been generated' do
-      expect(subject.last_value_if_set).to be_nil
+      expect(subject.send(:last_value)).to be_nil
     end
 
     it 'returns the last value after generating' do
       allow(described_class.backend).to receive(:nextval).and_return(42)
       subject.next
-      expect(subject.last_value_if_set).to eq 42
+      expect(subject.send(:last_value)).to eq 42
     end
 
     it 'returns nil after reset!' do
       allow(described_class.backend).to receive(:nextval).and_return(42)
       subject.next
       subject.reset!
-      expect(subject.last_value_if_set).to be_nil
+      expect(subject.send(:last_value)).to be_nil
     end
   end
 

--- a/spec/clever_sequence_spec.rb
+++ b/spec/clever_sequence_spec.rb
@@ -114,7 +114,62 @@ RSpec.describe CleverSequence do
     end
   end
 
+  describe '#last_value_if_set' do
+    let(:attribute) { :integer_column }
+
+    it 'returns nil when no value has been generated' do
+      expect(subject.last_value_if_set).to be_nil
+    end
+
+    it 'returns the last value after generating' do
+      allow(described_class.backend).to receive(:nextval).and_return(42)
+      subject.next
+      expect(subject.last_value_if_set).to eq 42
+    end
+
+    it 'returns nil after reset!' do
+      allow(described_class.backend).to receive(:nextval).and_return(42)
+      subject.next
+      subject.reset!
+      expect(subject.last_value_if_set).to be_nil
+    end
+  end
+
+  describe '.snapshot_last_values' do
+    let(:attribute) { :integer_column }
+
+    it 'returns empty hash when no sequences have been used' do
+      expect(described_class.snapshot_last_values).to eq({})
+    end
+
+    it 'captures last values for sequences that have been used' do
+      allow(described_class.backend).to receive(:nextval).and_return(10)
+      subject.next
+
+      snapshot = described_class.snapshot_last_values
+      expect(snapshot[%w(Widget integer_column)]).to eq 10
+    end
+
+    it 'excludes sequences that have not generated values' do
+      # subject is registered but not used
+      subject
+      expect(described_class.snapshot_last_values).to eq({})
+    end
+  end
+
   describe '.with_sequence_adjustment' do
+    it 'snapshots last values before resetting and passes them to the backend' do
+      allow(described_class.backend).to receive(:nextval).and_return(10)
+      # Use a sequence so there's a value to snapshot
+      described_class.next(klass, :integer_column)
+
+      expect(described_class.backend).to receive(:with_sequence_adjustment)
+        .with(last_values: hash_including(%w(Widget integer_column) => 10))
+        .and_yield
+
+      described_class.with_sequence_adjustment { nil }
+    end
+
     it 'resets sequences before delegating to the backend' do
       expect(described_class).to receive(:reset!).ordered
       expect(described_class.backend).to receive(:with_sequence_adjustment).ordered.and_yield

--- a/spec/clever_sequence_spec.rb
+++ b/spec/clever_sequence_spec.rb
@@ -263,7 +263,6 @@ RSpec.describe CleverSequence do
         expect(seq.next).to eq 'Foo #1'
         expect(seq.next).to eq 'Foo #2'
       end
-
     end
   end
 

--- a/spec/clever_sequence_spec.rb
+++ b/spec/clever_sequence_spec.rb
@@ -247,6 +247,29 @@ RSpec.describe CleverSequence do
         expect(subject.next).to eq '2016-05-17'.to_date
       end
     end
+
+    context 'when klass is not set (e.g. FactoryBot attributes_for)' do
+      subject { described_class.new(:integer_column) }
+
+      it 'increments using a simple instance-level counter without hitting the backend' do
+        expect(described_class.backend).not_to receive(:nextval)
+        expect(subject.next).to eq 1
+        expect(subject.next).to eq 2
+        expect(subject.next).to eq 3
+      end
+
+      it 'applies the block transformation' do
+        seq = described_class.new(:text_column) { |i| "Foo ##{i}" }
+        expect(seq.next).to eq 'Foo #1'
+        expect(seq.next).to eq 'Foo #2'
+      end
+
+      it 'produces unique values under concurrent access' do
+        threads = 20.times.map { Thread.new { subject.next } }
+        values = threads.map(&:value)
+        expect(values.uniq.length).to eq 20
+      end
+    end
   end
 
   describe '#last' do
@@ -267,6 +290,21 @@ RSpec.describe CleverSequence do
       seq.next
 
       expect(seq.last).to eq 'value_8'
+    end
+
+    context 'when klass is not set (e.g. FactoryBot attributes_for)' do
+      subject { described_class.new(:integer_column) }
+
+      it 'returns 0 before any value is generated' do
+        expect(described_class.backend).not_to receive(:starting_value)
+        expect(subject.last).to eq 0
+      end
+
+      it 'returns the last incremented value' do
+        subject.next
+        subject.next
+        expect(subject.last).to eq 2
+      end
     end
   end
 

--- a/spec/clever_sequence_spec.rb
+++ b/spec/clever_sequence_spec.rb
@@ -264,11 +264,6 @@ RSpec.describe CleverSequence do
         expect(seq.next).to eq 'Foo #2'
       end
 
-      it 'produces unique values under concurrent access' do
-        threads = Array.new(20) { Thread.new { subject.next } }
-        values = threads.map(&:value)
-        expect(values.uniq.length).to eq 20
-      end
     end
   end
 

--- a/spec/clever_sequence_spec.rb
+++ b/spec/clever_sequence_spec.rb
@@ -57,6 +57,26 @@ RSpec.describe CleverSequence do
     end
   end
 
+  describe '.retry_on_uniqueness_violation?' do
+    after do
+      described_class.retry_on_uniqueness_violation = true
+    end
+
+    it 'returns true by default' do
+      expect(described_class.retry_on_uniqueness_violation?).to be(true)
+    end
+
+    context 'when disabled' do
+      before do
+        described_class.retry_on_uniqueness_violation = false
+      end
+
+      it 'returns false' do
+        expect(described_class.retry_on_uniqueness_violation?).to be(false)
+      end
+    end
+  end
+
   describe '.backend' do
     after do
       described_class.use_database_sequences = false
@@ -271,6 +291,7 @@ RSpec.describe CleverSequence do
     after do
       described_class.use_database_sequences = false
       described_class.enforce_sequences_exist = false
+      described_class.retry_on_uniqueness_violation = true
     end
 
     it 'allows setting use_database_sequences within DemoMode.configure block' do
@@ -289,6 +310,15 @@ RSpec.describe CleverSequence do
       end
 
       expect(described_class.enforce_sequences_exist?).to be(true)
+    end
+
+    it 'allows setting retry_on_uniqueness_violation within DemoMode.configure block' do
+      klass = described_class
+      DemoMode.configure do
+        klass.retry_on_uniqueness_violation = false
+      end
+
+      expect(described_class.retry_on_uniqueness_violation?).to be(false)
     end
   end
 end

--- a/spec/clever_sequence_spec.rb
+++ b/spec/clever_sequence_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe CleverSequence do
       expect(described_class).to receive(:reset!).ordered
       expect(described_class.backend).to receive(:with_sequence_adjustment).ordered.and_yield
 
-      described_class.with_sequence_adjustment { }
+      described_class.with_sequence_adjustment { nil }
     end
 
     it 'delegates to the active backend' do

--- a/spec/clever_sequence_spec.rb
+++ b/spec/clever_sequence_spec.rb
@@ -94,6 +94,22 @@ RSpec.describe CleverSequence do
     end
   end
 
+  describe '.with_sequence_adjustment' do
+    it 'resets sequences before delegating to the backend' do
+      expect(described_class).to receive(:reset!).ordered
+      expect(described_class.backend).to receive(:with_sequence_adjustment).ordered.and_yield
+
+      described_class.with_sequence_adjustment { }
+    end
+
+    it 'delegates to the active backend' do
+      expect(described_class.backend).to receive(:with_sequence_adjustment).and_yield
+      executed = false
+      described_class.with_sequence_adjustment { executed = true }
+      expect(executed).to be true
+    end
+  end
+
   describe '.next' do
     it 'delegates to the backend and returns sequential values' do
       allow(described_class.backend).to receive(:nextval).and_return(1, 2, 3)


### PR DESCRIPTION
This PR adds a sequence adjustment capability that can be invoked if a `RecordNotUnique` or `RecordInvalid` error is thrown during persona generation. When calling `with_sequence_adjustment`, the `PostgresBackend` clears its cache and adjusts invoked sequences using LBF so that they realign with the database. In theory, this aims to:
- Make it easier to have sequences introduced with low starting values and have LBF find the "true" starting values on first failure. This means you don't need to run a discovery task to find lower bounds for all sequences prior to introducing database-backed sequences.
- Make it easier to recover from data integrity issues (e.g. gaps in data or other data synchronization issues). On error, LBF will attempt to find the next valid sequence value and go from there.

**Note:** See my comments in the diff for implementation discussion...