### PR TITLE
fix: avoid local-specific cli_spec failures

### DIFF
--- a/spec/demo_mode/cli_spec.rb
+++ b/spec/demo_mode/cli_spec.rb
@@ -19,13 +19,11 @@ RSpec.describe DemoMode::Cli do
     # Disable the spinner because it causes the program to freeze?
     allow(CLI::UI::Spinner).to receive(:spin).and_yield(spinner)
 
-    expected_output = include(
-      'the_everyperson',
-      '👤 :: user@example.org',
-      '🔑 :: testing123',
-      '🌐 :: http://localhost:3000/ohno/sessions/1',
-    )
-
-    expect { described_class.start }.to output(expected_output).to_stdout
+    expect { described_class.start }.to output(
+      include('the_everyperson')
+        .and(include('👤 :: user@example.org'))
+        .and(include('🔑 :: testing123'))
+        .and(match(/🌐 :: http:\/\/localhost:3000\/ohno\/sessions\/\d+/)),
+    ).to_stdout
   end
 end

--- a/spec/demo_mode/cli_spec.rb
+++ b/spec/demo_mode/cli_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DemoMode::Cli do
       include('the_everyperson')
         .and(include('👤 :: user@example.org'))
         .and(include('🔑 :: testing123'))
-        .and(match(/🌐 :: http:\/\/localhost:3000\/ohno\/sessions\/\d+/)),
+        .and(match(%r{🌐 :: http://localhost:3000/ohno/sessions/\d+})),
     ).to_stdout
   end
 end


### PR DESCRIPTION
This spec was failing locally but passing on CI due to different session identifiers. This changes the spec to assert that _a_ session id exists, but doesn't assert an exact number.