### PR TITLE
feat: support checksum-based persona invalidation

### DIFF
--- a/app/jobs/demo_mode/account_generation_job.rb
+++ b/app/jobs/demo_mode/account_generation_job.rb
@@ -9,7 +9,7 @@ module DemoMode
 
         signinable = persona.generate!(variant: session.variant, password: session.signinable_password, options: options)
         new_status = session.claimed_at? ? 'in_use' : 'available'
-        session.update!(signinable: signinable, status: new_status)
+        session.update!(signinable: signinable, status: new_status, persona_checksum: persona.file_checksum)
       end
     rescue StandardError => e
       session.update!(status: 'failed')

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -20,7 +20,8 @@ module DemoMode
     scope :unclaimed, -> { where(claimed_at: nil) }
     scope :claimed,   -> { where.not(claimed_at: nil) }
     scope :available_for, ->(persona_name, variant) {
-      available.unclaimed.where(persona_name: persona_name, variant: variant)
+      persona = DemoMode.personas.find { |p| p.name.to_s == persona_name.to_s }
+      available.unclaimed.where(persona_name: persona_name, variant: variant, persona_checksum: persona&.file_checksum)
     }
 
     validates :persona_name, :variant, presence: true

--- a/db/migrate/20260409000000_add_persona_checksum_to_demo_mode_sessions.rb
+++ b/db/migrate/20260409000000_add_persona_checksum_to_demo_mode_sessions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddPersonaChecksumToDemoModeSessions < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :demo_mode_sessions, :persona_checksum, :string
+  end
+end

--- a/lib/demo_mode/config.rb
+++ b/lib/demo_mode/config.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'digest'
 require_relative 'concerns/configurable'
 
 module DemoMode
@@ -121,13 +122,16 @@ module DemoMode
     private
 
     def auto_load_personas!
-      Rails.root.glob("#{personas_path}/**/*.rb").sort.each do |persona|
-        raise <<~ERROR if File.readlines(persona).grep(/DemoMode\.add_persona/).empty?
-          This file does not define a persona: #{persona}\n
+      Rails.root.glob("#{personas_path}/**/*.rb").sort.each do |persona_file|
+        raise <<~ERROR if File.readlines(persona_file).grep(/DemoMode\.add_persona/).empty?
+          This file does not define a persona: #{persona_file}\n
           Please use `DemoMode.add_persona`
         ERROR
 
-        load(persona)
+        checksum = Digest::SHA256.hexdigest(File.read(persona_file))
+        before_count = @personas.length
+        load(persona_file)
+        @personas[before_count..].each { |p| p.file_checksum = checksum }
       end
     end
   end

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -6,7 +6,7 @@ module DemoMode
   class Persona
     include ActiveModel::Model
 
-    attr_accessor :name
+    attr_accessor :name, :file_checksum
 
     validates :name, presence: true
     validate :persona_must_have_at_least_one_feature

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_03_31_000000) do
+ActiveRecord::Schema.define(version: 2026_04_09_000000) do
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "attempts", default: 0, null: false
     t.datetime "created_at", null: false
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2026_03_31_000000) do
     t.string "signinable_password", null: false
     t.string "status", default: "processing", null: false
     t.datetime "claimed_at", precision: nil
+    t.string "persona_checksum"
     t.index ["persona_name", "variant", "status", "claimed_at"], name: "index_demo_mode_sessions_on_pool_lookup"
     t.index ["signinable_type", "signinable_id"], name: "index_demo_mode_sessions_on_signinable_type_and_signinable_id"
   end

--- a/spec/jobs/demo_mode/account_generation_job_spec.rb
+++ b/spec/jobs/demo_mode/account_generation_job_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe DemoMode::AccountGenerationJob do
       )
   end
 
+  it 'stores the persona checksum on the session' do
+    described_class.perform_now(session)
+    expect(session.reload.persona_checksum).to eq(session.persona.file_checksum)
+  end
+
   context 'when the persona must exist' do
     let(:session) do
       session = DemoMode::Session.new(persona_name: :garbage)

--- a/spec/jobs/demo_mode/pool_hydration_job_spec.rb
+++ b/spec/jobs/demo_mode/pool_hydration_job_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe DemoMode::PoolHydrationJob do
         s = DemoMode::Session.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
         s.signinable = DummyUser.create!(name: 'test')
         s.status = 'available'
+        s.persona_checksum = s.persona&.file_checksum
         s.save!(validate: false)
 
         expect {
@@ -66,6 +67,7 @@ RSpec.describe DemoMode::PoolHydrationJob do
           s = DemoMode::Session.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
           s.signinable = DummyUser.create!(name: 'test')
           s.status = 'available'
+          s.persona_checksum = s.persona&.file_checksum
           s.save!(validate: false)
         end
 

--- a/spec/jobs/demo_mode/pool_hydration_job_spec.rb
+++ b/spec/jobs/demo_mode/pool_hydration_job_spec.rb
@@ -84,6 +84,21 @@ RSpec.describe DemoMode::PoolHydrationJob do
         }.to have_enqueued_job(described_class)
           .with(persona_name: :the_everyperson, variant: 'default', count: 3)
       end
+
+      it 'does not count stale sessions toward the pool target' do
+        2.times do
+          s = DemoMode::Session.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
+          s.signinable = DummyUser.create!(name: 'test')
+          s.status = 'available'
+          s.persona_checksum = 'stale_checksum'
+          s.save!(validate: false)
+        end
+
+        expect {
+          described_class.perform_now(persona_name: :the_everyperson, variant: 'default')
+        }.to have_enqueued_job(described_class)
+          .with(persona_name: :the_everyperson, variant: 'default', count: nil)
+      end
     end
   end
 end

--- a/spec/models/demo_mode/session_spec.rb
+++ b/spec/models/demo_mode/session_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe DemoMode::Session do
     it 'returns available unclaimed sessions matching persona and variant' do
       session = described_class.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
       session.status = 'available'
+      session.persona_checksum = session.persona&.file_checksum
       session.save!(validate: false)
 
       expect(described_class.available_for(:the_everyperson, 'default')).to include(session)
@@ -194,6 +195,7 @@ RSpec.describe DemoMode::Session do
       pooled = described_class.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
       pooled.signinable = DummyUser.create!(name: 'test')
       pooled.status = 'available'
+      pooled.persona_checksum = pooled.persona&.file_checksum
       pooled.save!(validate: false)
 
       result = described_class.claim_for(persona_name: :the_everyperson, variant: 'default')
@@ -221,6 +223,7 @@ RSpec.describe DemoMode::Session do
       pooled = described_class.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
       pooled.signinable = DummyUser.create!(name: 'test')
       pooled.status = 'available'
+      pooled.persona_checksum = pooled.persona&.file_checksum
       pooled.save!(validate: false)
 
       expect {

--- a/spec/models/demo_mode/session_spec.rb
+++ b/spec/models/demo_mode/session_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe DemoMode::Session do
 
       expect(described_class.available_for(:the_everyperson, 'default')).not_to include(session)
     end
+
+    it 'excludes sessions with a stale checksum' do
+      session = described_class.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
+      session.status = 'available'
+      session.persona_checksum = 'stale_checksum'
+      session.save!(validate: false)
+
+      expect(described_class.available_for(:the_everyperson, 'default')).not_to include(session)
+    end
+
+    it 'excludes sessions with no checksum' do
+      session = described_class.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
+      session.status = 'available'
+      session.save!(validate: false)
+
+      expect(described_class.available_for(:the_everyperson, 'default')).not_to include(session)
+    end
   end
 
   it 'validates persona name' do


### PR DESCRIPTION
## Persona Checksum-Based Pool Staleness Detection

Added a mechanism to detect and ignore stale pooled demo sessions when a persona definition changes.

### Problem

The persona pooling feature pre-generates demo accounts and stores them in `demo_mode_sessions`. If a persona's definition file changes (e.g. to comply with a new DB schema or app logic), previously pooled sessions become stale — they were generated against an old version of the persona and could cause test failures if claimed.

### Solution

At persona load time, a SHA256 checksum of each persona's source file is computed and stored on the `Persona` object. When a session is generated, its `persona_checksum` column is populated with the persona's checksum at that moment. The `available_for` scope — used both when claiming sessions and when checking pool fill levels — filters to only return sessions whose checksum matches the current persona's checksum.

Staleness is **implicit**: stale sessions are simply invisible to the pool. `PoolHydrationJob` naturally creates fresh replacements since stale sessions don't count toward the pool target.

### Notes

- Pre-migration sessions (with `NULL` checksum) are automatically treated as stale since `NULL != any_checksum`
- Personas loaded at test time without a file (programmatically defined) have `nil` checksum, and sessions generated from them also have `nil` — so `WHERE persona_checksum IS NULL` matches correctly in tests
- `DemoMode.personas` is memoized per process, so the `find` in `available_for` is a cheap in-memory scan, not a repeated file load
