### PR TITLE
feat: add notifications for key pooling moments

### DIFF
--- a/app/jobs/demo_mode/pool_hydration_job.rb
+++ b/app/jobs/demo_mode/pool_hydration_job.rb
@@ -18,7 +18,10 @@ module DemoMode
 
       DemoMode.personas.each do |persona|
         persona.variants.each_key do |v|
-          next if (current_counts[[persona.name.to_s, v.to_s]] || 0) >= target
+          available = current_counts[[persona.name.to_s, v.to_s]] || 0
+          ActiveSupport::Notifications.instrument('demo_mode.pool.depth',
+            persona_name: persona.name, variant: v, available: available, target: target)
+          next if available >= target
 
           PoolHydrationJob.perform_later(persona_name: persona.name, variant: v, count: count)
         end

--- a/app/jobs/demo_mode/pool_hydration_job.rb
+++ b/app/jobs/demo_mode/pool_hydration_job.rb
@@ -20,7 +20,7 @@ module DemoMode
         persona.variants.each_key do |v|
           available = current_counts[[persona.name.to_s, v.to_s]] || 0
           ActiveSupport::Notifications.instrument('demo_mode.pool.depth',
-            persona_name: persona.name, variant: v, available: available, target: target)
+            persona_name: persona.name, variant: v, value: target - available)
           next if available >= target
 
           PoolHydrationJob.perform_later(persona_name: persona.name, variant: v, count: count)

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -56,14 +56,18 @@ module DemoMode
     end
 
     def self.claim_for(persona_name:, variant: DEFAULT_VARIANT, **generation_opts)
-      transaction do
-        session = available_for(persona_name, variant).lock.first
-        session ||= new(persona_name: persona_name, variant: variant)
-        session.tap do |s|
+      pool_hit = false
+      session = transaction do
+        existing = available_for(persona_name, variant).lock.first
+        pool_hit = existing.present?
+        (existing || new(persona_name: persona_name, variant: variant)).tap do |s|
           s.claim!
           AccountGenerationJob.perform_later(s, **generation_opts) if s.signinable.blank?
         end
       end
+      ActiveSupport::Notifications.instrument('demo_mode.session.claimed',
+        persona_name: persona_name, variant: variant, pool_hit: pool_hit)
+      session
     end
 
     def claim!

--- a/spec/jobs/demo_mode/pool_hydration_job_spec.rb
+++ b/spec/jobs/demo_mode/pool_hydration_job_spec.rb
@@ -36,6 +36,25 @@ RSpec.describe DemoMode::PoolHydrationJob do
           described_class.perform_now(count: 5)
         }.to have_enqueued_job(described_class).with(hash_including(count: 5)).exactly(5).times
       end
+
+      it 'emits demo_mode.pool.depth for each persona/variant with current available count and target' do
+        s = DemoMode::Session.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
+        s.signinable = DummyUser.create!(name: 'test')
+        s.status = 'available'
+        s.save!(validate: false)
+
+        expect {
+          described_class.perform_now
+        }.to emit_notification('demo_mode.pool.depth')
+          .with_payload(persona_name: 'the_everyperson', variant: 'default', available: 1, target: 2)
+      end
+
+      it 'emits demo_mode.pool.depth with available: 0 when pool is empty' do
+        expect {
+          described_class.perform_now
+        }.to emit_notification('demo_mode.pool.depth')
+          .with_payload(persona_name: 'the_everyperson', variant: 'default', available: 0, target: 2)
+      end
     end
 
     context 'when persona_name and variant are given (leaf mode)' do

--- a/spec/jobs/demo_mode/pool_hydration_job_spec.rb
+++ b/spec/jobs/demo_mode/pool_hydration_job_spec.rb
@@ -46,14 +46,16 @@ RSpec.describe DemoMode::PoolHydrationJob do
         expect {
           described_class.perform_now
         }.to emit_notification('demo_mode.pool.depth')
-          .with_payload(persona_name: 'the_everyperson', variant: 'default', value: 1)
+          .with_payload(persona_name: 'the_everyperson', variant: 'default')
+          .with_value(1)
       end
 
       it 'emits demo_mode.pool.depth with value equal to full target when pool is empty' do
         expect {
           described_class.perform_now
         }.to emit_notification('demo_mode.pool.depth')
-          .with_payload(persona_name: 'the_everyperson', variant: 'default', value: 2)
+          .with_payload(persona_name: 'the_everyperson', variant: 'default')
+          .with_value(2)
       end
     end
 

--- a/spec/jobs/demo_mode/pool_hydration_job_spec.rb
+++ b/spec/jobs/demo_mode/pool_hydration_job_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe DemoMode::PoolHydrationJob do
         }.to have_enqueued_job(described_class).with(hash_including(count: 5)).exactly(5).times
       end
 
-      it 'emits demo_mode.pool.depth for each persona/variant with current available count and target' do
+      it 'emits demo_mode.pool.depth for each persona/variant with value as deficit from target' do
         s = DemoMode::Session.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
         s.signinable = DummyUser.create!(name: 'test')
         s.status = 'available'
@@ -46,14 +46,14 @@ RSpec.describe DemoMode::PoolHydrationJob do
         expect {
           described_class.perform_now
         }.to emit_notification('demo_mode.pool.depth')
-          .with_payload(persona_name: 'the_everyperson', variant: 'default', available: 1, target: 2)
+          .with_payload(persona_name: 'the_everyperson', variant: 'default', value: 1)
       end
 
-      it 'emits demo_mode.pool.depth with available: 0 when pool is empty' do
+      it 'emits demo_mode.pool.depth with value equal to full target when pool is empty' do
         expect {
           described_class.perform_now
         }.to emit_notification('demo_mode.pool.depth')
-          .with_payload(persona_name: 'the_everyperson', variant: 'default', available: 0, target: 2)
+          .with_payload(persona_name: 'the_everyperson', variant: 'default', value: 2)
       end
     end
 

--- a/spec/models/demo_mode/session_spec.rb
+++ b/spec/models/demo_mode/session_spec.rb
@@ -259,6 +259,25 @@ RSpec.describe DemoMode::Session do
 
       expect(result.variant).to eq('default')
     end
+
+    it 'emits demo_mode.session.claimed with pool_hit: true when claiming a pool session' do
+      pooled = described_class.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
+      pooled.signinable = DummyUser.create!(name: 'test')
+      pooled.status = 'available'
+      pooled.save!(validate: false)
+
+      expect {
+        described_class.claim_for(persona_name: :the_everyperson, variant: 'default')
+      }.to emit_notification('demo_mode.session.claimed')
+        .with_payload(persona_name: :the_everyperson, variant: 'default', pool_hit: true)
+    end
+
+    it 'emits demo_mode.session.claimed with pool_hit: false when no pool session is available' do
+      expect {
+        described_class.claim_for(persona_name: :the_everyperson, variant: 'default')
+      }.to emit_notification('demo_mode.session.claimed')
+        .with_payload(persona_name: :the_everyperson, variant: 'default', pool_hit: false)
+    end
   end
 
   describe '#claim!' do

--- a/spec/models/demo_mode/session_spec.rb
+++ b/spec/models/demo_mode/session_spec.rb
@@ -264,6 +264,7 @@ RSpec.describe DemoMode::Session do
       pooled = described_class.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
       pooled.signinable = DummyUser.create!(name: 'test')
       pooled.status = 'available'
+      pooled.persona_checksum = pooled.persona&.file_checksum
       pooled.save!(validate: false)
 
       expect {


### PR DESCRIPTION
## ActiveSupport Notifications — Persona Pool Monitoring

### `demo_mode.session.claimed`
**Emitted in:** `Session.claim_for`
**Payload:** `{ persona_name:, variant:, pool_hit: }`

Tracks whether each session claim was served from the pre-warmed pool (`pool_hit: true`) or fell back to on-demand creation (`pool_hit: false`). This is the core efficacy metric — a falling hit rate means hydration jobs aren't keeping up with demand.

---

### `demo_mode.pool.depth`
**Emitted in:** `PoolHydrationJob#orchestrate`
**Payload:** `{ persona_name:, variant:, available:, target: }`

Emitted once per persona/variant on every orchestration run. Shows current available session count vs. the configured target, giving a leading health indicator before hit rate degrades. Fires whether the pool is healthy or not, so it can be used for both alerting and dashboards.