### PR TITLE
feat: add ability to disable a persona

### DIFF
--- a/app/jobs/demo_mode/pool_hydration_job.rb
+++ b/app/jobs/demo_mode/pool_hydration_job.rb
@@ -26,6 +26,8 @@ module DemoMode
     end
 
     def hydrate(persona_name, variant, count)
+      return unless DemoMode.personas.any? { |p| p.name.to_s == persona_name.to_s }
+
       target = count || DemoMode.minimum_pool_size
       return if DemoMode::Session.available_for(persona_name, variant).count >= target
 

--- a/app/jobs/demo_mode/pool_hydration_job.rb
+++ b/app/jobs/demo_mode/pool_hydration_job.rb
@@ -26,7 +26,7 @@ module DemoMode
     end
 
     def hydrate(persona_name, variant, count)
-      return unless DemoMode.personas.any? { |p| p.name.to_s == persona_name.to_s }
+      return unless DemoMode.personas.any? { |p| p.name.to_s == persona_name.to_s && p.variants.key?(variant) }
 
       target = count || DemoMode.minimum_pool_size
       return if DemoMode::Session.available_for(persona_name, variant).count >= target

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -52,7 +52,7 @@ module DemoMode
 
     # Heads up: finding a persona is not guaranteed (e.g. past sessions)
     def persona
-      DemoMode.personas.find { |p| p.name.to_s == persona_name.to_s }
+      DemoMode.personas.find { |p| p.name.to_s == persona_name.to_s && p.variants.key?(variant) }
     end
 
     def self.claim_for(persona_name:, variant: DEFAULT_VARIANT, **generation_opts)

--- a/lib/demo_mode.rb
+++ b/lib/demo_mode.rb
@@ -36,6 +36,10 @@ module DemoMode
       configuration.persona(name, &)
     end
 
+    def personas
+      configuration.personas.select(&:enabled?)
+    end
+
     def callout_personas
       personas.select(&:callout?)
     end

--- a/lib/demo_mode/config.rb
+++ b/lib/demo_mode/config.rb
@@ -23,7 +23,6 @@ module DemoMode
     configurations << :icon
     configurations << :password
     configurations << :around_persona_generation
-    configurations << :personas
     configurations << :sign_up_path
     configurations << :sign_in_path
 

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -89,6 +89,14 @@ module DemoMode
       true
     end
 
+    def enabled(&block)
+      @enabled_condition = block
+    end
+
+    def enabled?
+      @enabled_condition ? @enabled_condition.call : true
+    end
+
     def callout(callout = true) # rubocop:disable Style/OptionalBooleanParameter
       @callout = callout
     end

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -53,13 +53,13 @@ module DemoMode
     end
 
     def variant(name, &block)
-      variants[name] = Variant.new(name: name).tap do |v|
+      (@variants ||= {}.with_indifferent_access)[name] = Variant.new(name: name).tap do |v|
         v.instance_eval(&block)
       end
     end
 
     def variants
-      @variants ||= {}.with_indifferent_access
+      (@variants ||= {}.with_indifferent_access).select { |_, v| v.enabled? }
     end
 
     def generate!(variant: :default, password: nil, options: {})
@@ -144,6 +144,14 @@ module DemoMode
     Variant = Struct.new(:name, keyword_init: true) do
       def sign_in_as(&signinable_generator)
         @signinable_generator = signinable_generator
+      end
+
+      def enabled(&block)
+        @enabled_condition = block
+      end
+
+      def enabled?
+        @enabled_condition ? @enabled_condition.call : true
       end
 
       def title

--- a/spec/demo_mode_spec.rb
+++ b/spec/demo_mode_spec.rb
@@ -245,6 +245,41 @@ RSpec.describe DemoMode do
       flag[0] = false
       expect(described_class.personas.map(&:name)).not_to include('dynamic_persona')
     end
+
+    context 'when a persona has a variant with enabled { false }' do
+      before do
+        described_class.add_persona('persona_with_variants') do
+          features << 'foo'
+          variant('enabled_variant') { sign_in_as { 'apple' } }
+          variant('disabled_variant') do
+            enabled { false }
+            sign_in_as { 'banana' }
+          end
+        end
+      end
+
+      it 'excludes the disabled variant from persona.variants' do
+        persona = described_class.personas.find { |p| p.name.to_s == 'persona_with_variants' }
+        expect(persona.variants.keys).to eq ['enabled_variant']
+      end
+    end
+
+    it 'evaluates the variant enabled block lazily at access time' do
+      flag = [true]
+      described_class.add_persona('persona_with_dynamic_variant') do
+        features << 'foo'
+        variant('dynamic_variant') do
+          enabled { flag[0] }
+          sign_in_as { 'banana' }
+        end
+      end
+
+      persona = described_class.personas.find { |p| p.name.to_s == 'persona_with_dynamic_variant' }
+      expect(persona.variants.keys).to include('dynamic_variant')
+
+      flag[0] = false
+      expect(persona.variants.keys).not_to include('dynamic_variant')
+    end
   end
 
   describe '.session_url' do

--- a/spec/demo_mode_spec.rb
+++ b/spec/demo_mode_spec.rb
@@ -213,6 +213,38 @@ RSpec.describe DemoMode do
           end
       ERR
     end
+
+    context 'when a persona has enabled { false }' do
+      before do
+        described_class.add_persona('disabled_persona') do
+          features << 'foo'
+          enabled { false }
+          sign_in_as { 'banana' }
+        end
+        described_class.add_persona('enabled_persona') do
+          features << 'bar'
+          sign_in_as { 'apple' }
+        end
+      end
+
+      it 'excludes the disabled persona from .personas' do
+        expect(described_class.personas.map(&:name)).to eq ['enabled_persona']
+      end
+    end
+
+    it 'evaluates the enabled block lazily at access time' do
+      flag = [true]
+      described_class.add_persona('dynamic_persona') do
+        features << 'foo'
+        enabled { flag[0] }
+        sign_in_as { 'banana' }
+      end
+
+      expect(described_class.personas.map(&:name)).to include('dynamic_persona')
+
+      flag[0] = false
+      expect(described_class.personas.map(&:name)).not_to include('dynamic_persona')
+    end
   end
 
   describe '.session_url' do

--- a/spec/jobs/demo_mode/pool_hydration_job_spec.rb
+++ b/spec/jobs/demo_mode/pool_hydration_job_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe DemoMode::PoolHydrationJob do
         expect { described_class.perform_now }.to have_enqueued_job(described_class).exactly(5).times
       end
 
+      it 'skips disabled personas' do
+        DemoMode.add_persona(:disabled_test_persona) do
+          features << 'test'
+          enabled { false }
+          sign_in_as { DummyUser.create!(name: 'test') }
+        end
+
+        expect { described_class.perform_now }.to have_enqueued_job(described_class).exactly(5).times
+      end
+
       it 'skips persona/variant combinations already at target' do
         s = DemoMode::Session.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
         s.signinable = DummyUser.create!(name: 'test')

--- a/spec/jobs/demo_mode/pool_hydration_job_spec.rb
+++ b/spec/jobs/demo_mode/pool_hydration_job_spec.rb
@@ -26,6 +26,19 @@ RSpec.describe DemoMode::PoolHydrationJob do
         expect { described_class.perform_now }.to have_enqueued_job(described_class).exactly(5).times
       end
 
+      it 'skips disabled variants' do
+        DemoMode.add_persona(:persona_with_disabled_variant) do
+          features << 'test'
+          variant('enabled_variant') { sign_in_as { DummyUser.create!(name: 'test') } }
+          variant('disabled_variant') do
+            enabled { false }
+            sign_in_as { DummyUser.create!(name: 'test') }
+          end
+        end
+
+        expect { described_class.perform_now }.to have_enqueued_job(described_class).exactly(6).times
+      end
+
       it 'skips persona/variant combinations already at target' do
         s = DemoMode::Session.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
         s.signinable = DummyUser.create!(name: 'test')
@@ -119,6 +132,22 @@ RSpec.describe DemoMode::PoolHydrationJob do
 
         expect {
           described_class.perform_now(persona_name: :disabled_test_persona, variant: 'default')
+        }.not_to have_enqueued_job(described_class)
+
+        expect(DemoMode::Session.count).to eq(0)
+      end
+
+      it 'does nothing when the variant is disabled' do
+        DemoMode.add_persona(:persona_with_disabled_variant) do
+          features << 'test'
+          variant('disabled_variant') do
+            enabled { false }
+            sign_in_as { DummyUser.create!(name: 'test') }
+          end
+        end
+
+        expect {
+          described_class.perform_now(persona_name: :persona_with_disabled_variant, variant: 'disabled_variant')
         }.not_to have_enqueued_job(described_class)
 
         expect(DemoMode::Session.count).to eq(0)

--- a/spec/jobs/demo_mode/pool_hydration_job_spec.rb
+++ b/spec/jobs/demo_mode/pool_hydration_job_spec.rb
@@ -109,6 +109,20 @@ RSpec.describe DemoMode::PoolHydrationJob do
         }.to have_enqueued_job(described_class)
           .with(persona_name: :the_everyperson, variant: 'default', count: nil)
       end
+
+      it 'does nothing when the persona is disabled' do
+        DemoMode.add_persona(:disabled_test_persona) do
+          features << 'test'
+          enabled { false }
+          sign_in_as { DummyUser.create!(name: 'test') }
+        end
+
+        expect {
+          described_class.perform_now(persona_name: :disabled_test_persona, variant: 'default')
+        }.not_to have_enqueued_job(described_class)
+
+        expect(DemoMode::Session.count).to eq(0)
+      end
     end
   end
 end

--- a/spec/models/demo_mode/session_spec.rb
+++ b/spec/models/demo_mode/session_spec.rb
@@ -108,6 +108,21 @@ RSpec.describe DemoMode::Session do
     expect(subject.errors.full_messages).to match_array("Persona must exist")
   end
 
+  it 'treats a disabled variant as non-existent on create' do
+    DemoMode.add_persona(:persona_with_disabled_variant) do
+      features << 'test'
+      variant('disabled_variant') do
+        enabled { false }
+        sign_in_as { DummyUser.create!(name: 'test') }
+      end
+    end
+
+    subject.persona_name = 'persona_with_disabled_variant'
+    subject.variant = 'disabled_variant'
+    expect(subject).not_to be_valid
+    expect(subject.errors.full_messages).to match_array("Persona must exist")
+  end
+
   it 'allows persisted records to reference non-existent personas' do
     subject.persona_name = :the_everyperson
     subject.variant = 'XIV'

--- a/spec/models/demo_mode/session_spec.rb
+++ b/spec/models/demo_mode/session_spec.rb
@@ -96,6 +96,18 @@ RSpec.describe DemoMode::Session do
     expect(subject.errors.full_messages).to match_array("Persona must exist")
   end
 
+  it 'treats a disabled persona as non-existent on create' do
+    DemoMode.add_persona(:disabled_persona) do
+      features << 'test'
+      enabled { false }
+      sign_in_as { DummyUser.create!(name: 'test') }
+    end
+
+    subject.persona_name = 'disabled_persona'
+    expect(subject).not_to be_valid
+    expect(subject.errors.full_messages).to match_array("Persona must exist")
+  end
+
   it 'allows persisted records to reference non-existent personas' do
     subject.persona_name = :the_everyperson
     subject.variant = 'XIV'


### PR DESCRIPTION
Adds an `enabled` property to `persona` that is `true` by default, but allows for disabling a persona conditionally. This can be useful if personas only apply in specific contexts, or if a persona if broken for some reason and needs to be disabled temporarily while a fix is in the works.