### PR TITLE
fix: ensure pool hydration job orchestration ignores checksum-invalid sessions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (3.7.0)
+    demo_mode (3.7.1)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/app/jobs/demo_mode/pool_hydration_job.rb
+++ b/app/jobs/demo_mode/pool_hydration_job.rb
@@ -14,11 +14,10 @@ module DemoMode
 
     def orchestrate(count)
       target = count || DemoMode.minimum_pool_size
-      current_counts = DemoMode::Session.available.group(:persona_name, :variant).count
 
       DemoMode.personas.each do |persona|
         persona.variants.each_key do |v|
-          available = current_counts[[persona.name.to_s, v.to_s]] || 0
+          available = DemoMode::Session.available_for(persona.name, v).count
           ActiveSupport::Notifications.instrument('demo_mode.pool.depth',
             persona_name: persona.name, variant: v, value: target - available)
           next if available >= target

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.7.0)
+    demo_mode (3.7.1)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.7.0)
+    demo_mode (3.7.1)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.7.0)
+    demo_mode (3.7.1)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '3.7.0'
+  VERSION = '3.7.1'
 end

--- a/spec/jobs/demo_mode/pool_hydration_job_spec.rb
+++ b/spec/jobs/demo_mode/pool_hydration_job_spec.rb
@@ -43,15 +43,29 @@ RSpec.describe DemoMode::PoolHydrationJob do
         s = DemoMode::Session.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
         s.signinable = DummyUser.create!(name: 'test')
         s.status = 'available'
+        s.persona_checksum = s.persona&.file_checksum
         s.save!(validate: false)
         2.times do
           s = DemoMode::Session.new(persona_name: :zendaya, variant: 'default', pool_session: true)
           s.signinable = DummyUser.create!(name: 'test')
           s.status = 'available'
+          s.persona_checksum = s.persona&.file_checksum
           s.save!(validate: false)
         end
 
         expect { described_class.perform_now }.to have_enqueued_job(described_class).exactly(4).times
+      end
+
+      it 'does not count stale-checksum sessions toward the pool target' do
+        2.times do
+          s = DemoMode::Session.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
+          s.signinable = DummyUser.create!(name: 'test')
+          s.status = 'available'
+          s.persona_checksum = 'stale_checksum'
+          s.save!(validate: false)
+        end
+
+        expect { described_class.perform_now }.to have_enqueued_job(described_class).exactly(5).times
       end
 
       it 'passes a custom count through to leaf jobs' do
@@ -64,6 +78,7 @@ RSpec.describe DemoMode::PoolHydrationJob do
         s = DemoMode::Session.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
         s.signinable = DummyUser.create!(name: 'test')
         s.status = 'available'
+        s.persona_checksum = s.persona&.file_checksum
         s.save!(validate: false)
 
         expect {


### PR DESCRIPTION
This PR fixes an issue that was causing the `PoolHydrationJob` orchestration codepath to include sessions that were invalid based on stale checksums in its "available sessions" logic because it was using `available` instead of `available_for`. Note that this change does involve an N+1 query count _but_ the alternatives seemed much nastier to me. I suspect it's something we could improve in the future if needed.