### PR TITLE
refactor: explicitly allow failed to processing transitions on a session for retries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (3.7.1)
+    demo_mode (3.7.2)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/app/jobs/demo_mode/account_generation_job.rb
+++ b/app/jobs/demo_mode/account_generation_job.rb
@@ -4,6 +4,7 @@ module DemoMode
   class AccountGenerationJob < DemoMode.base_job_name.constantize
     def perform(session, **options)
       session.with_lock do
+        session.update!(status: 'processing') if session.failed?
         persona = session.persona
         raise "Unknown persona: #{session.persona_name}" if persona.blank?
 

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -11,7 +11,7 @@ module DemoMode
     attr_accessor :pool_session
 
     steady_state :status do
-      state 'processing', default: true
+      state 'processing', default: true, from: 'failed'
       state 'available', from: 'processing'
       state 'in_use', from: %w(processing available)
       state 'failed', from: 'processing'

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.7.1)
+    demo_mode (3.7.2)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.7.1)
+    demo_mode (3.7.2)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.7.1)
+    demo_mode (3.7.2)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '3.7.1'
+  VERSION = '3.7.2'
 end


### PR DESCRIPTION
The introduction of `steady_state` prohibited transitions from `failed` to `in_use` or `available`, causing `Validation failed: Status is invalid` errors during retries invoked by external mechanisms (e.g. `Delayed`). This PR changes that to allow a change back to `processing` for retry. Existing allowances for `processing` to `in_use` or `available` allow for the remainder of the steps to complete.