### PR TITLE
feat: support disabling pooling for a persona

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (3.7.2)
+    demo_mode (3.8.2)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/app/jobs/demo_mode/pool_hydration_job.rb
+++ b/app/jobs/demo_mode/pool_hydration_job.rb
@@ -16,7 +16,11 @@ module DemoMode
       target = count || DemoMode.minimum_pool_size
 
       DemoMode.personas.each do |persona|
-        persona.variants.each_key do |v|
+        next unless persona.allow_in_pool?
+
+        persona.variants.each do |v, variant|
+          next unless variant.allow_in_pool?
+
           available = DemoMode::Session.available_for(persona.name, v).count
           ActiveSupport::Notifications.instrument('demo_mode.pool.depth',
             persona_name: persona.name, variant: v, value: target - available)
@@ -28,7 +32,9 @@ module DemoMode
     end
 
     def hydrate(persona_name, variant, count)
-      return unless DemoMode.personas.any? { |p| p.name.to_s == persona_name.to_s && p.variants.key?(variant) }
+      persona = DemoMode.personas.find { |p| p.name.to_s == persona_name.to_s && p.variants.key?(variant) }
+
+      return unless persona&.allow_in_pool?
 
       target = count || DemoMode.minimum_pool_size
       return if DemoMode::Session.available_for(persona_name, variant).count >= target

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -21,6 +21,8 @@ module DemoMode
     scope :claimed,   -> { where.not(claimed_at: nil) }
     scope :available_for, ->(persona_name, variant) {
       persona = DemoMode.personas.find { |p| p.name.to_s == persona_name.to_s }
+      return none unless persona&.allow_in_pool? && persona.variants[variant]&.allow_in_pool?
+
       available.unclaimed.where(persona_name: persona_name, variant: variant, persona_checksum: persona&.file_checksum)
     }
 
@@ -56,6 +58,7 @@ module DemoMode
     end
 
     def self.claim_for(persona_name:, variant: DEFAULT_VARIANT, **generation_opts)
+      persona = DemoMode.personas.find { |p| p.name.to_s == persona_name.to_s && p.variants.key?(variant) }
       pool_hit = false
       session = transaction do
         existing = available_for(persona_name, variant).lock.first
@@ -65,8 +68,10 @@ module DemoMode
           AccountGenerationJob.perform_later(s, **generation_opts) if s.signinable.blank?
         end
       end
-      ActiveSupport::Notifications.instrument('demo_mode.session.claimed',
-        persona_name: persona_name, variant: variant, pool_hit: pool_hit)
+      if persona&.allow_in_pool?
+        ActiveSupport::Notifications.instrument('demo_mode.session.claimed',
+          persona_name: persona_name, variant: variant, pool_hit: pool_hit)
+      end
       session
     end
 

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.7.2)
+    demo_mode (3.8.2)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.7.2)
+    demo_mode (3.8.2)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.7.2)
+    demo_mode (3.8.2)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -97,6 +97,14 @@ module DemoMode
       @enabled_condition ? @enabled_condition.call : true
     end
 
+    def allow_in_pool(&block)
+      @allow_in_pool_condition = block
+    end
+
+    def allow_in_pool?
+      @allow_in_pool_condition ? @allow_in_pool_condition.call : true
+    end
+
     def callout(callout = true) # rubocop:disable Style/OptionalBooleanParameter
       @callout = callout
     end
@@ -152,6 +160,14 @@ module DemoMode
 
       def enabled?
         @enabled_condition ? @enabled_condition.call : true
+      end
+
+      def allow_in_pool(&block)
+        @allow_in_pool_condition = block
+      end
+
+      def allow_in_pool?
+        @allow_in_pool_condition ? @allow_in_pool_condition.call : true
       end
 
       def title

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '3.7.2'
+  VERSION = '3.8.2'
 end

--- a/spec/jobs/demo_mode/pool_hydration_job_spec.rb
+++ b/spec/jobs/demo_mode/pool_hydration_job_spec.rb
@@ -39,6 +39,29 @@ RSpec.describe DemoMode::PoolHydrationJob do
         expect { described_class.perform_now }.to have_enqueued_job(described_class).exactly(6).times
       end
 
+      it 'skips personas with allow_in_pool? false' do
+        DemoMode.add_persona(:non_poolable_persona) do
+          features << 'test'
+          allow_in_pool { false }
+          sign_in_as { DummyUser.create!(name: 'test') }
+        end
+
+        expect { described_class.perform_now }.to have_enqueued_job(described_class).exactly(5).times
+      end
+
+      it 'skips variants with allow_in_pool? false' do
+        DemoMode.add_persona(:persona_with_non_poolable_variant) do
+          features << 'test'
+          variant('enabled_variant') { sign_in_as { DummyUser.create!(name: 'test') } }
+          variant('disabled_variant') do
+            allow_in_pool { false }
+            sign_in_as { DummyUser.create!(name: 'test') }
+          end
+        end
+
+        expect { described_class.perform_now }.to have_enqueued_job(described_class).exactly(6).times
+      end
+
       it 'skips persona/variant combinations already at target' do
         s = DemoMode::Session.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
         s.signinable = DummyUser.create!(name: 'test')

--- a/spec/models/demo_mode/session_spec.rb
+++ b/spec/models/demo_mode/session_spec.rb
@@ -82,6 +82,38 @@ RSpec.describe DemoMode::Session do
 
       expect(described_class.available_for(:the_everyperson, 'default')).not_to include(session)
     end
+
+    it 'excludes sessions for a persona with allow_in_pool? false' do
+      DemoMode.add_persona(:non_poolable_persona) do
+        features << 'test'                                                                                                                                                            
+        allow_in_pool { false }
+        sign_in_as { DummyUser.create!(name: 'test') }                                                                                                                                
+      end
+                                                                                                                                                                                      
+      session = described_class.new(persona_name: :non_poolable_persona, variant: 'default', pool_session: true)                                                                      
+      session.status = 'available'
+      session.persona_checksum = session.persona&.file_checksum                                                                                                                       
+      session.save!(validate: false)
+
+      expect(described_class.available_for(:non_poolable_persona, 'default')).not_to include(session)
+    end
+
+    it 'excludes sessions for a variant with allow_in_pool? false' do
+      DemoMode.add_persona(:persona_with_not_allowed_variant) do
+        features << 'test'
+        variant('not_allowed_variant') do
+          sign_in_as { DummyUser.create!(name: 'test') }
+          allow_in_pool { false }
+        end
+      end
+
+      session = described_class.new(persona_name: :persona_with_not_allowed_variant, variant: 'not_allowed_variant', pool_session: true)                                                                      
+      session.status = 'available'
+      session.persona_checksum = session.persona&.file_checksum                                                                                                                       
+      session.save!(validate: false)
+
+      expect(described_class.available_for(:persona_with_not_allowed_variant, 'not_allowed_variant')).not_to include(session)
+    end
   end
 
   it 'validates persona name' do
@@ -298,6 +330,23 @@ RSpec.describe DemoMode::Session do
         described_class.claim_for(persona_name: :the_everyperson, variant: 'default')
       }.to emit_notification('demo_mode.session.claimed')
         .with_payload(persona_name: :the_everyperson, variant: 'default', pool_hit: true)
+    end
+
+    it 'does not emit demo_mode.session.claimed for a persona with allow_in_pool? false' do
+      DemoMode.add_persona(:non_poolable_persona) do
+        features << 'test'                                                                                                                                                            
+        allow_in_pool { false }
+        sign_in_as { DummyUser.create!(name: 'test') }                                                                                                                                
+      end
+                                                                                                                                                                                      
+      session = described_class.new(persona_name: :non_poolable_persona, variant: 'default', pool_session: true)                                                                      
+      session.status = 'available'
+      session.persona_checksum = session.persona&.file_checksum                                                                                                                       
+      session.save!(validate: false)
+
+      expect {
+        described_class.claim_for(persona_name: :non_poolable_persona, variant: 'default')
+      }.not_to emit_notification('demo_mode.session.claimed')
     end
 
     it 'emits demo_mode.session.claimed with pool_hit: false when no pool session is available' do

--- a/spec/models/demo_mode/session_spec.rb
+++ b/spec/models/demo_mode/session_spec.rb
@@ -85,14 +85,17 @@ RSpec.describe DemoMode::Session do
 
     it 'excludes sessions for a persona with allow_in_pool? false' do
       DemoMode.add_persona(:non_poolable_persona) do
-        features << 'test'                                                                                                                                                            
+        features << 'test'
         allow_in_pool { false }
-        sign_in_as { DummyUser.create!(name: 'test') }                                                                                                                                
+        sign_in_as do
+          DummyUser.create!(name: 'test')
+        end
       end
-                                                                                                                                                                                      
-      session = described_class.new(persona_name: :non_poolable_persona, variant: 'default', pool_session: true)                                                                      
+
+      session = described_class.new(persona_name: :non_poolable_persona, variant: 'default',
+        pool_session: true)
       session.status = 'available'
-      session.persona_checksum = session.persona&.file_checksum                                                                                                                       
+      session.persona_checksum = session.persona&.file_checksum
       session.save!(validate: false)
 
       expect(described_class.available_for(:non_poolable_persona, 'default')).not_to include(session)
@@ -107,9 +110,10 @@ RSpec.describe DemoMode::Session do
         end
       end
 
-      session = described_class.new(persona_name: :persona_with_not_allowed_variant, variant: 'not_allowed_variant', pool_session: true)                                                                      
+      session = described_class.new(persona_name: :persona_with_not_allowed_variant, variant: 'not_allowed_variant',
+        pool_session: true)
       session.status = 'available'
-      session.persona_checksum = session.persona&.file_checksum                                                                                                                       
+      session.persona_checksum = session.persona&.file_checksum
       session.save!(validate: false)
 
       expect(described_class.available_for(:persona_with_not_allowed_variant, 'not_allowed_variant')).not_to include(session)
@@ -334,14 +338,17 @@ RSpec.describe DemoMode::Session do
 
     it 'does not emit demo_mode.session.claimed for a persona with allow_in_pool? false' do
       DemoMode.add_persona(:non_poolable_persona) do
-        features << 'test'                                                                                                                                                            
+        features << 'test'
         allow_in_pool { false }
-        sign_in_as { DummyUser.create!(name: 'test') }                                                                                                                                
+        sign_in_as do
+          DummyUser.create!(name: 'test')
+        end
       end
-                                                                                                                                                                                      
-      session = described_class.new(persona_name: :non_poolable_persona, variant: 'default', pool_session: true)                                                                      
+
+      session = described_class.new(persona_name: :non_poolable_persona, variant: 'default',
+        pool_session: true)
       session.status = 'available'
-      session.persona_checksum = session.persona&.file_checksum                                                                                                                       
+      session.persona_checksum = session.persona&.file_checksum
       session.save!(validate: false)
 
       expect {


### PR DESCRIPTION
This PR allows for disabling pooling behavior for a given persona.

This is useful in some cases where a persona has behavior/attributes that are time-sensitive, i.e. an expiring invite or similar that, if pooled, would expire prior to being claimed.

By setting `allow_in_pool { false }`, you disable pooling and a new persona will always be generated when requested. The persona will never be hydrated.