### PR TITLE
feat: at_claim callback to support time-sensitive behavior

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (3.7.2)
+    demo_mode (3.8.0)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/app/jobs/demo_mode/account_generation_job.rb
+++ b/app/jobs/demo_mode/account_generation_job.rb
@@ -9,8 +9,14 @@ module DemoMode
         raise "Unknown persona: #{session.persona_name}" if persona.blank?
 
         signinable = persona.generate!(variant: session.variant, password: session.signinable_password, options: options)
+        session.update!(signinable: signinable, persona_checksum: persona.file_checksum)
+
+        if session.claimed_at?
+          persona.effective_at_claim_callback(session.variant)&.call(signinable)
+        end
+
         new_status = session.claimed_at? ? 'in_use' : 'available'
-        session.update!(signinable: signinable, status: new_status, persona_checksum: persona.file_checksum)
+        session.update!(status: new_status)
       end
     rescue StandardError => e
       session.update!(status: 'failed')

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -58,18 +58,15 @@ module DemoMode
     def self.claim_for(persona_name:, variant: DEFAULT_VARIANT, **generation_opts)
       persona = DemoMode.personas.find { |p| p.name.to_s == persona_name.to_s && p.variants.key?(variant) }
       pool_hit = false
-      claim_error = nil
       session = transaction do
         existing = available_for(persona_name, variant).lock.first
         pool_hit = existing.present?
         if existing
-          claim_pool_session(existing, persona, variant) { |e| claim_error = e }
+          claim_pool_session(existing, persona, variant)
         else
           new_claimed_session(persona_name, variant, generation_opts)
         end
       end
-      raise claim_error if claim_error
-
       ActiveSupport::Notifications.instrument('demo_mode.session.claimed',
         persona_name: persona_name, variant: variant, pool_hit: pool_hit)
       session
@@ -79,12 +76,15 @@ module DemoMode
       private
 
       def claim_pool_session(session, persona, variant)
-        persona&.effective_at_claim_callback(variant)&.call(session.signinable)
-        session.claim!
-        session
-      rescue StandardError => e
-        yield e
-        session.update!(status: 'failed')
+        claimed = false
+        transaction(requires_new: true) do
+          persona&.effective_at_claim_callback(variant)&.call(session.signinable)
+          session.claim!
+          claimed = true
+        rescue StandardError
+          raise ActiveRecord::Rollback
+        end
+        session.update!(status: 'failed') unless claimed
         session
       end
 

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -14,7 +14,7 @@ module DemoMode
       state 'processing', default: true, from: 'failed'
       state 'available', from: 'processing'
       state 'in_use', from: %w(processing available)
-      state 'failed', from: 'processing'
+      state 'failed', from: %w(processing available)
     end
 
     scope :unclaimed, -> { where(claimed_at: nil) }
@@ -56,18 +56,44 @@ module DemoMode
     end
 
     def self.claim_for(persona_name:, variant: DEFAULT_VARIANT, **generation_opts)
+      persona = DemoMode.personas.find { |p| p.name.to_s == persona_name.to_s && p.variants.key?(variant) }
       pool_hit = false
+      claim_error = nil
       session = transaction do
         existing = available_for(persona_name, variant).lock.first
         pool_hit = existing.present?
-        (existing || new(persona_name: persona_name, variant: variant)).tap do |s|
+        if existing
+          claim_pool_session(existing, persona, variant) { |e| claim_error = e }
+        else
+          new_claimed_session(persona_name, variant, generation_opts)
+        end
+      end
+      raise claim_error if claim_error
+
+      ActiveSupport::Notifications.instrument('demo_mode.session.claimed',
+        persona_name: persona_name, variant: variant, pool_hit: pool_hit)
+      session
+    end
+
+    class << self
+      private
+
+      def claim_pool_session(session, persona, variant)
+        persona&.effective_at_claim_callback(variant)&.call(session.signinable)
+        session.claim!
+        session
+      rescue StandardError => e
+        yield e
+        session.update!(status: 'failed')
+        session
+      end
+
+      def new_claimed_session(persona_name, variant, generation_opts)
+        new(persona_name: persona_name, variant: variant).tap do |s|
           s.claim!
           AccountGenerationJob.perform_later(s, **generation_opts) if s.signinable.blank?
         end
       end
-      ActiveSupport::Notifications.instrument('demo_mode.session.claimed',
-        persona_name: persona_name, variant: variant, pool_hit: pool_hit)
-      session
     end
 
     def claim!

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -76,15 +76,13 @@ module DemoMode
       private
 
       def claim_pool_session(session, persona, variant)
-        claimed = false
         transaction(requires_new: true) do
           persona&.effective_at_claim_callback(variant)&.call(session.signinable)
           session.claim!
-          claimed = true
         rescue StandardError
           raise ActiveRecord::Rollback
         end
-        session.update!(status: 'failed') unless claimed
+        session.update!(status: 'failed') unless session.claimed_at?
         session
       end
 

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.7.2)
+    demo_mode (3.8.0)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.7.2)
+    demo_mode (3.8.0)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.7.2)
+    demo_mode (3.8.0)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -97,6 +97,16 @@ module DemoMode
       @enabled_condition ? @enabled_condition.call : true
     end
 
+    def at_claim(&block)
+      @at_claim_callback = block
+    end
+
+    attr_reader :at_claim_callback
+
+    def effective_at_claim_callback(variant_name)
+      variants[variant_name]&.at_claim_callback || @at_claim_callback
+    end
+
     def callout(callout = true) # rubocop:disable Style/OptionalBooleanParameter
       @callout = callout
     end
@@ -154,10 +164,15 @@ module DemoMode
         @enabled_condition ? @enabled_condition.call : true
       end
 
+      def at_claim(&block)
+        @at_claim_callback = block
+      end
+
       def title
         name.is_a?(Symbol) ? name.to_s.titleize : name.to_s
       end
 
+      attr_reader :at_claim_callback
       attr_reader :signinable_generator
     end
   end

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '3.7.2'
+  VERSION = '3.8.0'
 end

--- a/spec/demo_mode_spec.rb
+++ b/spec/demo_mode_spec.rb
@@ -282,6 +282,66 @@ RSpec.describe DemoMode do
     end
   end
 
+  context 'when a persona has persona-level at_claim_callback' do
+    before do
+      described_class.add_persona('at_claim_persona') do
+        features << 'foo'
+        at_claim { |signinable| "#{signinable}-foo" }
+        variant('default') do
+          sign_in_as { 'banana' }
+        end
+      end
+    end
+
+    it 'returns the at_claim_callback' do
+      persona = described_class.personas.find { |p| p.name.to_s == 'at_claim_persona' }
+
+      value = persona.effective_at_claim_callback('default')&.call('banana')
+
+      expect(value).to eq('banana-foo')
+    end
+  end
+
+  context 'when a persona has variant-level at_claim_callback' do
+    before do
+      described_class.add_persona('at_claim_persona') do
+        features << 'foo'
+        variant('default') do
+          at_claim { |signinable| "#{signinable}-foo" }
+          sign_in_as { 'banana' }
+        end
+      end
+    end
+
+    it 'returns the at_claim_callback' do
+      persona = described_class.personas.find { |p| p.name.to_s == 'at_claim_persona' }
+
+      value = persona.effective_at_claim_callback('default')&.call('banana')
+
+      expect(value).to eq('banana-foo')
+    end
+  end
+
+  context 'when a persona has both a persona-level and variant-level at_claim_callback' do
+    before do
+      described_class.add_persona('at_claim_persona') do
+        features << 'foo'
+        at_claim { |signinable| "#{signinable}-bar" }
+        variant('default') do
+          at_claim { |signinable| "#{signinable}-foo" }
+          sign_in_as { 'banana' }
+        end
+      end
+    end
+
+    it 'returns the variant at_claim_callback' do
+      persona = described_class.personas.find { |p| p.name.to_s == 'at_claim_persona' }
+
+      value = persona.effective_at_claim_callback('default')&.call('banana')
+
+      expect(value).to eq('banana-foo')
+    end
+  end
   describe '.session_url' do
     let(:session) { DemoMode::Session.new(id: 2) }
     let(:demo_mode_options) { {} }

--- a/spec/jobs/demo_mode/account_generation_job_spec.rb
+++ b/spec/jobs/demo_mode/account_generation_job_spec.rb
@@ -24,6 +24,54 @@ RSpec.describe DemoMode::AccountGenerationJob do
       )
   end
 
+  context 'when the persona has an at_claim callback' do
+    before do
+      DemoMode.add_persona('at_claim_persona') do
+        features << 'test'
+        at_claim { |u| u.update!(name: 'claimed') }
+        sign_in_as { DummyUser.create!(name: 'original') }
+      end
+    end
+
+    context 'when the session was claimed (pool miss)' do
+      let(:session) { DemoMode::Session.create!(persona_name: 'at_claim_persona') }
+
+      it 'invokes the callback after account generation' do
+        described_class.perform_now(session)
+        expect(session.reload.signinable.name).to eq('claimed')
+      end
+    end
+
+    context 'when the session is a pool pre-generation' do
+      let(:session) { DemoMode::Session.create!(persona_name: 'at_claim_persona', pool_session: true) }
+
+      it 'does not invoke the callback' do
+        described_class.perform_now(session)
+        expect(session.reload.signinable.name).to eq('original')
+      end
+    end
+
+    context 'when the at_claim callback raises' do
+      before do
+        DemoMode.add_persona('erroring_at_claim_persona') do
+          features << 'test'
+          at_claim { |_| raise 'oops!' }
+          sign_in_as { DummyUser.create!(name: 'original') }
+        end
+      end
+
+      let(:session) { DemoMode::Session.create!(persona_name: 'erroring_at_claim_persona') }
+
+      it 'marks the session as failed and re-raises' do
+        expect {
+          described_class.perform_now(session)
+        }.to raise_error(RuntimeError, 'oops!')
+
+        expect(session.reload.status).to eq('failed')
+      end
+    end
+  end
+
   it 'stores the persona checksum on the session' do
     described_class.perform_now(session)
     expect(session.reload.persona_checksum).to eq(session.persona.file_checksum)

--- a/spec/jobs/demo_mode/account_generation_job_spec.rb
+++ b/spec/jobs/demo_mode/account_generation_job_spec.rb
@@ -62,12 +62,11 @@ RSpec.describe DemoMode::AccountGenerationJob do
 
       let(:session) { DemoMode::Session.create!(persona_name: 'erroring_at_claim_persona') }
 
-      it 'marks the session as failed and re-raises' do
+      it 'marks the session as failed and re-raises the error' do
         expect {
           described_class.perform_now(session)
         }.to raise_error(RuntimeError, 'oops!')
-
-        expect(session.reload.status).to eq('failed')
+          .and change { session.reload.status }.to('failed')
       end
     end
   end

--- a/spec/models/demo_mode/session_spec.rb
+++ b/spec/models/demo_mode/session_spec.rb
@@ -287,6 +287,48 @@ RSpec.describe DemoMode::Session do
       expect(result.variant).to eq('default')
     end
 
+    context 'when a pooled session has an at_claim callback' do
+      before do
+        DemoMode.add_persona :at_claim_persona do
+          features << 'test'
+          sign_in_as { DummyUser.create!(name: 'before_claim') }
+          at_claim { |u| u.update!(name: 'after_claim') }
+        end
+      end
+
+      it 'invokes the at_claim callback' do
+        pooled = described_class.new(persona_name: :at_claim_persona, variant: 'default', pool_session: true)
+        pooled.signinable = DummyUser.create!(name: 'before_claim')
+        pooled.status = 'available'
+        pooled.persona_checksum = pooled.persona&.file_checksum
+        pooled.save!(validate: false)
+
+        result = described_class.claim_for(persona_name: :at_claim_persona)
+
+        expect(result.reload.signinable.name).to eq('after_claim')
+      end
+
+      it 'marks the session as failed and re-raises when the at_claim callback raises' do
+        DemoMode.add_persona :at_claim_error_persona do
+          features << 'test'
+          sign_in_as { DummyUser.create!(name: 'test') }
+          at_claim { |_| raise 'at_claim failed' }
+        end
+
+        pooled = described_class.new(persona_name: :at_claim_error_persona, variant: 'default', pool_session: true)
+        pooled.signinable = DummyUser.create!(name: 'test')
+        pooled.status = 'available'
+        pooled.persona_checksum = pooled.persona&.file_checksum
+        pooled.save!(validate: false)
+
+        expect {
+          described_class.claim_for(persona_name: :at_claim_error_persona)
+        }.to raise_error(RuntimeError, 'at_claim failed')
+
+        expect(pooled.reload.status).to eq('failed')
+      end
+    end
+
     it 'emits demo_mode.session.claimed with pool_hit: true when claiming a pool session' do
       pooled = described_class.new(persona_name: :the_everyperson, variant: 'default', pool_session: true)
       pooled.signinable = DummyUser.create!(name: 'test')

--- a/spec/models/demo_mode/session_spec.rb
+++ b/spec/models/demo_mode/session_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe DemoMode::Session do
         expect(result.reload.signinable.name).to eq('after_claim')
       end
 
-      it 'marks the session as failed and re-raises when the at_claim callback raises' do
+      it 'marks the session as failed when the at_claim callback raises' do
         DemoMode.add_persona :at_claim_error_persona do
           features << 'test'
           sign_in_as { DummyUser.create!(name: 'test') }
@@ -321,11 +321,9 @@ RSpec.describe DemoMode::Session do
         pooled.persona_checksum = pooled.persona&.file_checksum
         pooled.save!(validate: false)
 
-        expect {
-          described_class.claim_for(persona_name: :at_claim_error_persona)
-        }.to raise_error(RuntimeError, 'at_claim failed')
+        result = described_class.claim_for(persona_name: :at_claim_error_persona)
 
-        expect(pooled.reload.status).to eq('failed')
+        expect(result.reload.status).to eq('failed')
       end
     end
 

--- a/spec/requests/demo_mode/sessions_spec.rb
+++ b/spec/requests/demo_mode/sessions_spec.rb
@@ -199,6 +199,31 @@ RSpec.describe DemoMode::SessionsController do # rubocop:disable RSpec/FilePath
         end
       end
 
+      context 'with a pooled session available but at_claim raises (pool hit failure)' do
+        before do
+          DemoMode.add_persona('at_claim_error_persona') do
+            features << 'test'
+            at_claim { |_| raise 'at_claim failed' }
+            sign_in_as { DummyUser.create!(name: 'test') }
+          end
+        end
+
+        it 'returns a failed session' do
+          pooled = DemoMode::Session.new(persona_name: 'at_claim_error_persona', variant: 'default')
+          pooled.pool_session = true
+          pooled.save!
+          DemoMode::AccountGenerationJob.perform_now(pooled)
+
+          post '/ohno/sessions', params: {
+            session: { persona_name: 'at_claim_error_persona' },
+          }.to_json, headers: request_headers
+
+          expect(response_json['id']).to eq pooled.id
+          expect(response_json['status']).to eq 'failed'
+          expect(response_json['processing']).to be false
+        end
+      end
+
       context 'with no pooled session available (pool miss)' do
         it 'falls back to async generation and returns processing json' do
           post '/ohno/sessions', params: {


### PR DESCRIPTION
This PR adds an `at_claim` callback to `Persona` that allows invoking specific behavior when a session for the given `Persona` is being claimed. This is helpful when you have pooling enabled but also have time-sensitive attributes/behavior associated with the persona (e.g. an expiring invitation). Without this, an invite may expire before the persona is ever claimed. Now, you can use `at_claim` block to update the invitations expiration time so the session given to the caller is valid for a test/demo.

Note the following behavior based on whether the session has already been pooled or not. The goal is to ensure that a user never receives a session where `at_claim` failed, leaving the session in a wonky state.

**Pool hit** — the callback runs synchronously inside the transaction in `claim_for`, before `claim!` transitions the session to `in_use`. The session is still `available` at that point. If the callback raises, the session is marked `failed` and the error propagates to the caller.

**Pool miss** — the callback runs inside `AccountGenerationJob`, after the account is generated and the signinable is persisted, but before the session transitions to `in_use`. The session is still `processing` at that point. If the callback raises, the existing rescue marks the session `failed` and re-raises.