### PR TITLE
fix: wrap persona generation in savepoints to survive uniqueness violations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (3.8.0)
+    demo_mode (3.8.1)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/app/jobs/demo_mode/account_generation_job.rb
+++ b/app/jobs/demo_mode/account_generation_job.rb
@@ -3,25 +3,23 @@
 module DemoMode
   class AccountGenerationJob < DemoMode.base_job_name.constantize
     def perform(session, **options)
-      session.with_lock do
-        ActiveRecord::Base.transaction(requires_new: true) do
-          session.update!(status: 'processing') if session.failed?
-          persona = session.persona
-          raise "Unknown persona: #{session.persona_name}" if persona.blank?
+      session.with_lock(requires_new: true) do
+        session.update!(status: 'processing') if session.failed?
+        persona = session.persona
+        raise "Unknown persona: #{session.persona_name}" if persona.blank?
 
-          signinable = persona.generate!(variant: session.variant, password: session.signinable_password, options: options)
-          session.update!(signinable: signinable, persona_checksum: persona.file_checksum)
+        signinable = persona.generate!(variant: session.variant, password: session.signinable_password, options: options)
+        session.update!(signinable: signinable, persona_checksum: persona.file_checksum)
 
-          if session.claimed_at?
-            persona.effective_at_claim_callback(session.variant)&.call(signinable)
-          end
-
-          new_status = session.claimed_at? ? 'in_use' : 'available'
-          session.update!(status: new_status)
+        if session.claimed_at?
+          persona.effective_at_claim_callback(session.variant)&.call(signinable)
         end
+
+        new_status = session.claimed_at? ? 'in_use' : 'available'
+        session.update!(status: new_status)
       end
     rescue StandardError => e
-      ActiveRecord::Base.transaction(requires_new: true) { session.update!(status: 'failed') }
+      session.update!(status: 'failed')
       raise e
     end
   end

--- a/app/jobs/demo_mode/account_generation_job.rb
+++ b/app/jobs/demo_mode/account_generation_job.rb
@@ -4,22 +4,24 @@ module DemoMode
   class AccountGenerationJob < DemoMode.base_job_name.constantize
     def perform(session, **options)
       session.with_lock do
-        session.update!(status: 'processing') if session.failed?
-        persona = session.persona
-        raise "Unknown persona: #{session.persona_name}" if persona.blank?
+        ActiveRecord::Base.transaction(requires_new: true) do
+          session.update!(status: 'processing') if session.failed?
+          persona = session.persona
+          raise "Unknown persona: #{session.persona_name}" if persona.blank?
 
-        signinable = persona.generate!(variant: session.variant, password: session.signinable_password, options: options)
-        session.update!(signinable: signinable, persona_checksum: persona.file_checksum)
+          signinable = persona.generate!(variant: session.variant, password: session.signinable_password, options: options)
+          session.update!(signinable: signinable, persona_checksum: persona.file_checksum)
 
-        if session.claimed_at?
-          persona.effective_at_claim_callback(session.variant)&.call(signinable)
+          if session.claimed_at?
+            persona.effective_at_claim_callback(session.variant)&.call(signinable)
+          end
+
+          new_status = session.claimed_at? ? 'in_use' : 'available'
+          session.update!(status: new_status)
         end
-
-        new_status = session.claimed_at? ? 'in_use' : 'available'
-        session.update!(status: new_status)
       end
     rescue StandardError => e
-      session.update!(status: 'failed')
+      ActiveRecord::Base.transaction(requires_new: true) { session.update!(status: 'failed') }
       raise e
     end
   end

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -103,10 +103,10 @@ module DemoMode
       end
     end
 
-    def save_and_generate_account!(**options)
+    def save_and_generate_account!(**)
       transaction do
         save!
-        AccountGenerationJob.perform_now(self, **options)
+        AccountGenerationJob.perform_now(self, **)
       end
     end
 

--- a/app/models/demo_mode/session.rb
+++ b/app/models/demo_mode/session.rb
@@ -103,10 +103,10 @@ module DemoMode
       end
     end
 
-    def save_and_generate_account!(**)
+    def save_and_generate_account!(**options)
       transaction do
         save!
-        AccountGenerationJob.perform_now(self, **)
+        AccountGenerationJob.perform_now(self, **options)
       end
     end
 

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.8.0)
+    demo_mode (3.8.1)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.8.0)
+    demo_mode (3.8.1)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.8.0)
+    demo_mode (3.8.1)
       actionpack (>= 7.2, < 8.2)
       activejob (>= 7.2, < 8.2)
       activerecord (>= 7.2, < 8.2)

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -68,13 +68,17 @@ module DemoMode
         variant = variants[variant]
         CleverSequence.reset! if defined?(CleverSequence)
         DemoMode.current_password = password if password
-        DemoMode.around_persona_generation.call(variant.signinable_generator, **options)
+        ActiveRecord::Base.transaction(requires_new: true) do
+          DemoMode.around_persona_generation.call(variant.signinable_generator, **options)
+        end
       rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
         raise if retried || !should_retry_with_sequence_adjustment?(e)
 
         retried = true
         CleverSequence.with_sequence_adjustment do
-          DemoMode.around_persona_generation.call(variant.signinable_generator, **options)
+          ActiveRecord::Base.transaction(requires_new: true) do
+            DemoMode.around_persona_generation.call(variant.signinable_generator, **options)
+          end
         end
       ensure
         DemoMode.current_password = nil

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '3.8.0'
+  VERSION = '3.8.1'
 end

--- a/spec/jobs/demo_mode/account_generation_job_spec.rb
+++ b/spec/jobs/demo_mode/account_generation_job_spec.rb
@@ -69,6 +69,25 @@ RSpec.describe DemoMode::AccountGenerationJob do
           .and change { session.reload.status }.to('failed')
       end
     end
+
+    context 'when the at_claim callback raises a uniqueness violation' do
+      before do
+        DemoMode.add_persona('uniqueness_violating_at_claim_persona') do
+          features << 'test'
+          at_claim { |u| DummyUser.create!(id: u.id, name: 'duplicate') }
+          sign_in_as { DummyUser.create!(name: 'original') }
+        end
+      end
+
+      # Exercise the joinable outer transaction in save_and_generate_account! so the
+      # PG-aborted state would propagate without the savepoint inside #perform.
+      it 'propagates the original RecordNotUnique through the joinable outer transaction' do
+        session = DemoMode::Session.new(persona_name: 'uniqueness_violating_at_claim_persona')
+        expect {
+          session.save_and_generate_account!
+        }.to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
   end
 
   it 'stores the persona checksum on the session' do


### PR DESCRIPTION
Adds savepoints in key persona generation places to ensure that the desired cleanup/follow-up logic can actually run as desired.

**Persona#generate**

Wraps each call to `around_persona_generation.call(...)` (the initial attempt and the retry inside `with_sequence_adjustment`) in `ActiveRecord::Base.transaction(requires_new: true)`. When the _initial_ attempt raises `RecordNotUnique`, the savepoint allows Postgres to roll back to the savepoint cleanly, so the rescue handler can delegate to `CleverSequence's` `setval` and the retry can run successfully. Without it, the rescue's queries hit the PG-aborted transaction and surface the `PG:InFailedSqlTransaction` instead of recovering.

**AccountGenerationJob#perform**

Uses `requires_new: true` in the `with_lock`. If `at_claim` raises a uniqueness violation, the savepoint lets Rails rollback to the savepoint on the way out of the lock body, leaving the outer transaction valid so the rescue's update can run and the original exception can propagate to the caller.