### PR TITLE
feat: rake task for generating migrations with missing sequences for PostgresBackend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 
 ### Added <!-- for new features. -->
 
+- `clever_sequence:discover` rake task that discovers required PostgreSQL sequences for the `CleverSequence` `PostgresBackend` and prints migration instructions for any that are missing.
+
 ### Changed <!-- for changes in existing functionality. -->
 
 ### Deprecated <!-- for soon-to-be removed features. -->

--- a/README.md
+++ b/README.md
@@ -573,6 +573,14 @@ You can check this setting with:
 CleverSequence.enforce_sequences_exist? # => false (default)
 ```
 
+To find out which PostgreSQL sequences your personas actually need, run:
+
+```sh
+bundle exec rake clever_sequence:discover
+```
+
+This iterates every persona/variant in a rolled-back transaction, captures any `CleverSequence` calls that would have hit a missing sequence, and prints a ready-to-paste migration body for the missing sequences. It must be run in `development` and is a no-op once every required sequence already exists.
+
 ### Persona Pooling
 
 By default, Demo Mode generates persona accounts on-demand when a user clicks the persona picker. This means each click triggers a background job, and the user waits on a loading spinner. With persona pooling, accounts are pre-generated in the background so that sign-in is near-instant.

--- a/lib/demo_mode/clever_sequence/migration_generator.rb
+++ b/lib/demo_mode/clever_sequence/migration_generator.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require_relative 'postgres_backend'
+
+# rubocop:disable Rails/Output
+class CleverSequence
+  class MigrationGenerator
+    class << self
+      def discover_missing
+        raise 'CleverSequence sequence discovery can only be run in development' unless Rails.env.development?
+
+        puts 'Discovering required CleverSequence sequences...'
+        puts "Found #{DemoMode.personas.count} personas to process"
+
+        # Enable database sequences mode so we can discover all required sequences
+        CleverSequence.use_database_sequences = true
+        # Disable retries so RecordNotUnique/RecordInvalid errors propagate instead of
+        # triggering with_sequence_adjustment which would reset the sequence cache and
+        # lose discovered Missing entries
+        CleverSequence.retry_on_uniqueness_violation = false
+
+        missing_sequences = harvest_missing_sequences
+        puts "\n"
+        missing_sequences.values.map(&:to_h)
+      ensure
+        CleverSequence.use_database_sequences = false
+        CleverSequence.enforce_sequences_exist = false
+        CleverSequence.retry_on_uniqueness_violation = true
+      end
+
+      private
+
+      # Persona#generate! calls CleverSequence.reset! at the start of every persona,
+      # which wipes Thread.current[:clever_sequence_cache]. Harvest after each
+      # persona so Missing entries from earlier personas aren't lost. When the same
+      # sequence is missed by multiple personas, keep the one with the highest
+      # calculated_start_value so the generated migration covers every caller.
+      def harvest_missing_sequences
+        missing_sequences = {}
+
+        DemoMode.personas.each_with_index do |persona, index|
+          persona.variants.each_key do |variant|
+            print_progress(persona, variant, index)
+            generate_persona_in_rolled_back_transaction(persona, variant)
+            collect_missing_into(missing_sequences)
+          end
+        end
+
+        missing_sequences
+      end
+
+      def print_progress(persona, variant, index)
+        progress = "Processing persona #{index + 1}/#{DemoMode.personas.count}: #{persona.name}:#{variant}"
+        print "\r#{progress}".ljust(80)
+      end
+
+      def generate_persona_in_rolled_back_transaction(persona, variant)
+        ActiveRecord::Base.transaction do
+          persona.generate!(variant:)
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      def collect_missing_into(missing_sequences)
+        CleverSequence::PostgresBackend.sequence_cache.each_value do |result|
+          next unless result.is_a?(CleverSequence::PostgresBackend::SequenceResult::Missing)
+
+          existing = missing_sequences[result.sequence_name]
+          if existing.nil? || result.calculated_start_value > existing.calculated_start_value
+            missing_sequences[result.sequence_name] = result
+          end
+        end
+      end
+    end
+
+    def initialize(sequence_data)
+      @sequences = sequence_data
+        .map { |data| normalize_sequence_data(data) }
+        .sort_by { |s| s[:sequence_name] }
+    end
+
+    def up_sql
+      lines = []
+      lines << 'safety_assured do'
+      lines << '  execute <<~SQL'
+      @sequences.each do |seq|
+        lines << "    CREATE SEQUENCE IF NOT EXISTS \"#{seq[:sequence_name]}\" START WITH #{seq[:start_value]};"
+      end
+      lines << '  SQL'
+      lines << 'end'
+      lines.join("\n")
+    end
+
+    def down_sql
+      lines = []
+      lines << 'safety_assured do'
+      lines << '  execute <<~SQL'
+      @sequences.each do |seq|
+        lines << "    DROP SEQUENCE IF EXISTS \"#{seq[:sequence_name]}\";"
+      end
+      lines << '  SQL'
+      lines << 'end'
+      lines.join("\n")
+    end
+
+    def ci_output
+      <<~OUTPUT
+        ===== Missing CleverSequence Sequences =====
+
+        The following PostgreSQL sequences are required but do not exist:
+        #{sequence_list}
+
+        To create a migration, run:
+          bundle exec rails generate migration <YourMigrationName>
+
+        Then add the following to your migration:
+
+        def up
+          #{up_sql.gsub("\n", "\n    ")}
+        end
+
+        def down
+          #{down_sql.gsub("\n", "\n    ")}
+        end
+      OUTPUT
+    end
+
+    private
+
+    def normalize_sequence_data(data)
+      {
+        sequence_name: data[:sequence_name],
+        klass_name: data[:klass].name,
+        attribute: data[:attribute].to_s,
+        start_value: data[:calculated_start_value],
+      }
+    end
+
+    def sequence_list
+      @sequences.map { |seq|
+        "  - #{seq[:sequence_name]} (#{seq[:klass_name]}##{seq[:attribute]}, start: #{seq[:start_value]})"
+      }.join("\n")
+    end
+  end
+end
+# rubocop:enable Rails/Output

--- a/lib/demo_mode/tasks.rb
+++ b/lib/demo_mode/tasks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Rails/Output
+
 require 'demo_mode/cli'
 
 namespace :persona do
@@ -8,3 +10,20 @@ namespace :persona do
     DemoMode::Cli.start
   end
 end
+
+namespace :clever_sequence do
+  desc 'Discover all required PostgreSQL sequences for CleverSequence PostgresBackend'
+  task discover: :environment do
+    require 'demo_mode/clever_sequence/migration_generator'
+
+    missing = CleverSequence::MigrationGenerator.discover_missing
+
+    if missing.any?
+      puts CleverSequence::MigrationGenerator.new(missing).ci_output
+    else
+      puts 'All sequences exist! No migration needed.'
+    end
+  end
+end
+
+# rubocop:enable Rails/Output

--- a/spec/clever_sequence/migration_generator_spec.rb
+++ b/spec/clever_sequence/migration_generator_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'demo_mode/clever_sequence/migration_generator'
+
+RSpec.describe CleverSequence::MigrationGenerator do
+  let(:fake_klass) do
+    Class.new do
+      def self.name
+        'FakeModel'
+      end
+    end
+  end
+
+  describe '#ci_output' do
+    subject(:output) { described_class.new(sequence_data).ci_output }
+
+    context 'with a single sequence' do
+      let(:sequence_data) do
+        [
+          { sequence_name: 'cs_fake_models_email', klass: fake_klass, attribute: :email, calculated_start_value: 10 },
+        ]
+      end
+
+      it 'generates migration instructions' do
+        expected = <<~OUTPUT
+          ===== Missing CleverSequence Sequences =====
+
+          The following PostgreSQL sequences are required but do not exist:
+            - cs_fake_models_email (FakeModel#email, start: 10)
+
+          To create a migration, run:
+            bundle exec rails generate migration <YourMigrationName>
+
+          Then add the following to your migration:
+
+          def up
+            safety_assured do
+                execute <<~SQL
+                  CREATE SEQUENCE IF NOT EXISTS "cs_fake_models_email" START WITH 10;
+                SQL
+              end
+          end
+
+          def down
+            safety_assured do
+                execute <<~SQL
+                  DROP SEQUENCE IF EXISTS "cs_fake_models_email";
+                SQL
+              end
+          end
+        OUTPUT
+
+        expect(output).to eq expected
+      end
+    end
+
+    context 'with multiple sequences that require ordering' do
+      let(:sequence_data) do
+        [
+          { sequence_name: 'cs_zebra', klass: fake_klass, attribute: :name, calculated_start_value: 1 },
+          { sequence_name: 'cs_apple', klass: fake_klass, attribute: :id, calculated_start_value: 100 },
+        ]
+      end
+
+      it 'generates sorted migration instructions' do
+        expected = <<~OUTPUT
+          ===== Missing CleverSequence Sequences =====
+
+          The following PostgreSQL sequences are required but do not exist:
+            - cs_apple (FakeModel#id, start: 100)
+            - cs_zebra (FakeModel#name, start: 1)
+
+          To create a migration, run:
+            bundle exec rails generate migration <YourMigrationName>
+
+          Then add the following to your migration:
+
+          def up
+            safety_assured do
+                execute <<~SQL
+                  CREATE SEQUENCE IF NOT EXISTS "cs_apple" START WITH 100;
+                  CREATE SEQUENCE IF NOT EXISTS "cs_zebra" START WITH 1;
+                SQL
+              end
+          end
+
+          def down
+            safety_assured do
+                execute <<~SQL
+                  DROP SEQUENCE IF EXISTS "cs_apple";
+                  DROP SEQUENCE IF EXISTS "cs_zebra";
+                SQL
+              end
+          end
+        OUTPUT
+
+        expect(output).to eq expected
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a rake task (`clever_sequence:discover`) that exercises all `DemoMode.personas` and keeps track of `Missing` entries that indicate a missing Postgres sequence that would have been utilized in generating one or more of your personas. 

Note that creating these sequences is _ideal_ when `use_db_sequences` is `true` for improved performance (it avoids falling back to `LowerBoundFinder`) and _required_ when `enforce_sequences_exist` is `true` (otherwise a `SequenceNotFoundError` is thrown during persona generation).