### PR TITLE
feat: Add persona grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,11 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 
-- Optional persona grouping. Set a group with `group 'My Group'` inside `add_persona`. Grouped personas
-  render in collapsed `<details>` sections on the splash page, and search filters across every group
-  (opening a collapsed group when a match is inside it). Ungrouped personas render in the existing
-  table, so the change is backward compatible.
+- Optional persona grouping. Set a group with `group 'My Group'` inside `add_persona`, or opt into
+  deriving groups from persona subfolders with `config.group_by_folder = true`. Grouped personas render
+  in collapsed `<details>` sections on the splash page, and search filters across every group (opening a
+  collapsed group when a match is inside it). Ungrouped personas render in the existing table, so the
+  change is backward compatible.
 
 ## [3.10.0] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 
 ### Fixed <!-- for any bug fixes. -->
 
+## [3.11.0] - 2026-08-20
+
+### Added
+
+- Optional persona grouping. Set a group with `group 'My Group'` inside `add_persona`. Grouped personas
+  render in collapsed `<details>` sections on the splash page, and search filters across every group
+  (opening a collapsed group when a match is inside it). Ungrouped personas render in the existing
+  table, so the change is backward compatible.
+
 ## [3.10.0] - 2026-08-10
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 
 ### Fixed <!-- for any bug fixes. -->
 
-## [3.11.0] - 2026-08-26
+## [3.11.0] - 2026-08-28
 
 ### Added
 
@@ -29,6 +29,9 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 
 - `ungrouped_first` config (default `true`) to control whether ungrouped personas render before or
   after named groups
+
+- `groups` config to control the display order of named groups (array or hash), and to give groups
+  human-friendly labels (hash form, keyed by the group's raw name).
 
 ## [3.10.0] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 
 ### Fixed <!-- for any bug fixes. -->
 
-## [3.11.0] - 2026-08-20
+## [3.11.0] - 2026-08-26
 
 ### Added
 
@@ -26,6 +26,9 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
   in collapsed `<details>` sections on the splash page, and search filters across every group (opening a
   collapsed group when a match is inside it). Ungrouped personas render in the existing table, so the
   change is backward compatible.
+
+- `ungrouped_first` config (default `true`) to control whether ungrouped personas render before or
+  after named groups
 
 ## [3.10.0] - 2026-08-10
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    demo_mode (3.10.0)
+    demo_mode (3.11.0)
       actionpack (>= 8.0, < 8.2)
       activejob (>= 8.0, < 8.2)
       activerecord (>= 8.0, < 8.2)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To learn more about how we use `demo_mode` at **Betterment**, check out :sparkle
   - [Installation](#installation)
   - [App-Specific Setup](#app-specific-setup)
 - [Defining Personas](#defining-personas)
+  - [Grouping Personas](#grouping-personas)
 - [Customizing the Design](#customizing-the-design)
 - [Optional Features](#optional-features)
   - [The "Sign Up" Link](#the-sign-up-link)
@@ -272,6 +273,27 @@ end
 
 If defined, the non-variant `sign_in_as` will show up as "default" in the
 dropdown.
+
+### Grouping Personas
+
+When an app has many personas, the single table can get hard to scan. You can
+optionally organize personas into collapsible groups. Grouping is entirely
+opt-in: personas without a group render in the table exactly as before.
+
+Set a group name directly on a persona:
+
+```ruby
+DemoMode.add_persona do
+  group 'Playwright tests'
+  features << 'Account Overview'
+  # ...
+end
+```
+
+Personas that share a group name render together in a collapsed `<details>`
+section (labeled with the group name and a count), while ungrouped personas stay
+in the main table. The search box filters across every group and automatically
+opens a collapsed group when a match is found inside it.
 
 ## Customizing the Design
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,32 @@ DemoMode.configure do
   ungrouped_first false
 end
 ```
+
+You can also control the order groups render in, and give them human-friendly
+labels, with `groups`. Pass an array to set the order (any group not listed
+falls back to alphabetical, after the listed ones):
+
+```ruby
+DemoMode.configure do
+  groups %w(transactions activity locked)
+end
+```
+
+Or pass a hash to set the order *and* a friendly label, using the group's raw
+name (e.g. a folder path like `orders/checkout`) as the key:
+
+```ruby
+DemoMode.configure do
+  groups(
+    'orders' => 'Orders',
+    'orders/checkout' => 'Checkout',
+  )
+end
+```
+
+`groups` only affects named groups; use `ungrouped_first` to control where
+ungrouped personas render relative to them.
+
 ## Customizing the Design
 
 To supply your own branding, you can override the logo

--- a/README.md
+++ b/README.md
@@ -311,6 +311,15 @@ compacted into a single label (e.g. `orders/checkout`). An explicit `group` alwa
 overrides the folder-derived group, and personas at the root of `personas_path`
 remain ungrouped.
 
+By default, ungrouped personas render above every named group (matching the
+pre-grouping table layout). Set `ungrouped_first` to `false` to render them
+after the named groups instead:
+
+```ruby
+DemoMode.configure do
+  ungrouped_first false
+end
+```
 ## Customizing the Design
 
 To supply your own branding, you can override the logo

--- a/README.md
+++ b/README.md
@@ -295,6 +295,22 @@ section (labeled with the group name and a count), while ungrouped personas stay
 in the main table. The search box filters across every group and automatically
 opens a collapsed group when a match is found inside it.
 
+Alternatively, if you already organize your persona files into subfolders (e.g.
+`config/personas/orders/...`, `config/personas/advanced/...`), you can derive groups from
+that folder structure with a single config flag:
+
+```ruby
+DemoMode.configure do
+  group_by_folder true
+end
+```
+
+With `group_by_folder` enabled, each persona's group defaults to its subfolder
+(relative to `personas_path`). Folders nested more than one level deep are
+compacted into a single label (e.g. `orders/checkout`). An explicit `group` always
+overrides the folder-derived group, and personas at the root of `personas_path`
+remain ungrouped.
+
 ## Customizing the Design
 
 To supply your own branding, you can override the logo

--- a/app/views/demo_mode/sessions/_grouped_personas.html.erb
+++ b/app/views/demo_mode/sessions/_grouped_personas.html.erb
@@ -1,0 +1,9 @@
+<% DemoMode.grouped_personas.each do |group, personas| %>
+  <% next if group.nil? %>
+  <section>
+    <details class="persona-group">
+      <summary><%= group %> (<%= personas.count %>)</summary>
+      <%= render 'persona_table', personas: personas %>
+    </details>
+  </section>
+<% end %>

--- a/app/views/demo_mode/sessions/_grouped_personas.html.erb
+++ b/app/views/demo_mode/sessions/_grouped_personas.html.erb
@@ -1,8 +1,7 @@
-<% DemoMode.grouped_personas.each do |group, personas| %>
-  <% next if group.nil? %>
+<% named_groups.each do |name, personas| %>
   <section>
     <details class="persona-group">
-      <summary><%= group %> (<%= personas.count %>)</summary>
+      <summary><%= name %> (<%= personas.count %>)</summary>
       <%= render 'persona_table', personas: personas %>
     </details>
   </section>

--- a/app/views/demo_mode/sessions/_persona_table.html.erb
+++ b/app/views/demo_mode/sessions/_persona_table.html.erb
@@ -1,0 +1,28 @@
+<table class="persona-table">
+  <thead>
+    <tr>
+      <th></th>
+      <th>Persona name</th>
+      <th>Variant</th>
+      <th>Features</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% personas.each do |persona| %>
+      <tr class="<%= persona.css_class %>">
+        <td>
+          <%= form_for @session, html: { id: persona.name.to_s.underscore } do |f| %>
+            <%= f.hidden_field :persona_name, value: persona.name %>
+            <%= f.submit 'Sign In', class: 'secondary small' %>
+            <% @f = f %>
+          <% end %>
+        </td>
+        <td><%= persona.name.to_s.titleize %></td>
+        <td>
+          <%= render 'variant_dropdown', f: @f, persona: persona %>
+        </td>
+        <td><%= persona.features.join(", ") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/demo_mode/sessions/_ungrouped_personas.html.erb
+++ b/app/views/demo_mode/sessions/_ungrouped_personas.html.erb
@@ -1,0 +1,5 @@
+<% if DemoMode.ungrouped_personas.any? %>
+  <section>
+    <%= render 'persona_table', personas: DemoMode.ungrouped_personas %>
+  </section>
+<% end %>

--- a/app/views/demo_mode/sessions/_ungrouped_personas.html.erb
+++ b/app/views/demo_mode/sessions/_ungrouped_personas.html.erb
@@ -1,5 +1,5 @@
-<% if DemoMode.ungrouped_personas.any? %>
+<% if personas.any? %>
   <section>
-    <%= render 'persona_table', personas: DemoMode.ungrouped_personas %>
+    <%= render 'persona_table', personas: personas %>
   </section>
 <% end %>

--- a/app/views/demo_mode/sessions/new.html.erb
+++ b/app/views/demo_mode/sessions/new.html.erb
@@ -23,35 +23,19 @@
     <section>
       <input type="text" placeholder="Search..." data-table="persona-table" data-behavior="table-filter" />
     </section>
-    <section>
-      <table class="persona-table">
-        <thead>
-          <tr>
-            <th></th>
-            <th>Persona name</th>
-            <th>Variant</th>
-            <th>Features</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% DemoMode.standard_personas.each do |persona| %>
-            <tr class="<%= persona.css_class %>">
-              <td>
-                <%= form_for @session, html: { id: persona.name.to_s.underscore } do |f| %>
-                  <%= f.hidden_field :persona_name, value: persona.name %>
-                  <%= f.submit 'Sign In', class: 'secondary small' %>
-                  <% @f = f %>
-                <% end %>
-              </td>
-              <td><%= persona.name.to_s.titleize %></td>
-              <td>
-                <%= render 'variant_dropdown', f: @f, persona: persona %>
-              </td>
-              <td><%= persona.features.join(", ") %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </section>
+    <% if DemoMode.ungrouped_personas.any? %>
+      <section>
+        <%= render 'persona_table', personas: DemoMode.ungrouped_personas %>
+      </section>
+    <% end %>
+    <% DemoMode.grouped_personas.each do |group, personas| %>
+      <% next if group.nil? %>
+      <section>
+        <details class="persona-group">
+          <summary><%= group %> (<%= personas.count %>)</summary>
+          <%= render 'persona_table', personas: personas %>
+        </details>
+      </section>
+    <% end %>
   </article>
 <% end %>

--- a/app/views/demo_mode/sessions/new.html.erb
+++ b/app/views/demo_mode/sessions/new.html.erb
@@ -23,19 +23,12 @@
     <section>
       <input type="text" placeholder="Search..." data-table="persona-table" data-behavior="table-filter" />
     </section>
-    <% if DemoMode.ungrouped_personas.any? %>
-      <section>
-        <%= render 'persona_table', personas: DemoMode.ungrouped_personas %>
-      </section>
-    <% end %>
-    <% DemoMode.grouped_personas.each do |group, personas| %>
-      <% next if group.nil? %>
-      <section>
-        <details class="persona-group">
-          <summary><%= group %> (<%= personas.count %>)</summary>
-          <%= render 'persona_table', personas: personas %>
-        </details>
-      </section>
+    <% if DemoMode.ungrouped_first? %>
+      <%= render 'ungrouped_personas' %>
+      <%= render 'grouped_personas' %>
+    <% else %>
+      <%= render 'grouped_personas' %>
+      <%= render 'ungrouped_personas' %>
     <% end %>
   </article>
 <% end %>

--- a/app/views/demo_mode/sessions/new.html.erb
+++ b/app/views/demo_mode/sessions/new.html.erb
@@ -24,11 +24,11 @@
       <input type="text" placeholder="Search..." data-table="persona-table" data-behavior="table-filter" />
     </section>
     <% if DemoMode.ungrouped_first? %>
-      <%= render 'ungrouped_personas' %>
-      <%= render 'grouped_personas' %>
+      <%= render 'ungrouped_personas', personas: DemoMode.grouper.ungrouped %>
+      <%= render 'grouped_personas', named_groups: DemoMode.grouper.named_groups %>
     <% else %>
-      <%= render 'grouped_personas' %>
-      <%= render 'ungrouped_personas' %>
+      <%= render 'grouped_personas', named_groups: DemoMode.grouper.named_groups %>
+      <%= render 'ungrouped_personas', personas: DemoMode.grouper.ungrouped %>
     <% end %>
   </article>
 <% end %>

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.10.0)
+    demo_mode (3.11.0)
       actionpack (>= 8.0, < 8.2)
       activejob (>= 8.0, < 8.2)
       activerecord (>= 8.0, < 8.2)

--- a/gemfiles/rails_8_1.gemfile.lock
+++ b/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    demo_mode (3.10.0)
+    demo_mode (3.11.0)
       actionpack (>= 8.0, < 8.2)
       activejob (>= 8.0, < 8.2)
       activerecord (>= 8.0, < 8.2)

--- a/lib/demo_mode.rb
+++ b/lib/demo_mode.rb
@@ -48,6 +48,14 @@ module DemoMode
       personas - callout_personas
     end
 
+    def grouped_personas
+      standard_personas.group_by(&:group)
+    end
+
+    def ungrouped_personas
+      grouped_personas.fetch(nil, [])
+    end
+
     def current_password
       Thread.current[:_demo_mode_password] ||= password.call
     end

--- a/lib/demo_mode.rb
+++ b/lib/demo_mode.rb
@@ -6,6 +6,7 @@ require 'demo_mode/version'
 require 'demo_mode/clever_sequence'
 require 'demo_mode/config'
 require 'demo_mode/engine'
+require 'demo_mode/grouper'
 require 'demo_mode/persona'
 
 module DemoMode
@@ -48,12 +49,8 @@ module DemoMode
       personas - callout_personas
     end
 
-    def grouped_personas
-      standard_personas.group_by(&:group)
-    end
-
-    def ungrouped_personas
-      grouped_personas.fetch(nil, [])
+    def grouper
+      Grouper.new(standard_personas, groups: groups)
     end
 
     def current_password

--- a/lib/demo_mode/config.rb
+++ b/lib/demo_mode/config.rb
@@ -19,6 +19,7 @@ module DemoMode
     configurable_boolean(:display_credentials)
     configurable_boolean(:group_by_folder)
     configurable_boolean(:ungrouped_first, default: true)
+    configurable_value(:groups) { [] }
     configurations << :stylesheets
     configurations << :logo
     configurations << :loader

--- a/lib/demo_mode/config.rb
+++ b/lib/demo_mode/config.rb
@@ -18,6 +18,7 @@ module DemoMode
     configurable_value(:minimum_pool_size) { 5 }
     configurable_boolean(:display_credentials)
     configurable_boolean(:group_by_folder)
+    configurable_boolean(:ungrouped_first, default: true)
     configurations << :stylesheets
     configurations << :logo
     configurations << :loader

--- a/lib/demo_mode/config.rb
+++ b/lib/demo_mode/config.rb
@@ -17,6 +17,7 @@ module DemoMode
     configurable_value(:log_level) { :debug }
     configurable_value(:minimum_pool_size) { 5 }
     configurable_boolean(:display_credentials)
+    configurable_boolean(:group_by_folder)
     configurations << :stylesheets
     configurations << :logo
     configurations << :loader
@@ -130,7 +131,10 @@ module DemoMode
         checksum = Digest::SHA256.hexdigest(File.read(persona_file))
         before_count = @personas.length
         load(persona_file)
-        @personas[before_count..].each { |p| p.file_checksum = checksum }
+        @personas[before_count..].each do |p|
+          p.file_checksum = checksum
+          p.file_path = persona_file.to_s
+        end
       end
     end
   end

--- a/lib/demo_mode/grouper.rb
+++ b/lib/demo_mode/grouper.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module DemoMode
+  class Grouper
+    def initialize(personas, groups:)
+      @personas = personas
+      @groups = groups
+    end
+
+    def named
+      buckets.except(nil).sort_by { |group, _| sort_key(group) }
+    end
+
+    def named_groups
+      named.map { |group, personas| [name_for(group), personas] }
+    end
+
+    def ungrouped
+      buckets.fetch(nil, [])
+    end
+
+    def name_for(group)
+      return group unless groups.is_a?(Hash)
+
+      groups.stringify_keys[group.to_s] || group
+    end
+
+    private
+
+    attr_reader :personas, :groups
+
+    def buckets
+      personas.group_by(&:group)
+    end
+
+    def sort_key(group)
+      rank = group_keys.index(group.to_s)
+      [rank || Float::INFINITY, group.to_s]
+    end
+
+    def group_keys
+      (groups.is_a?(Hash) ? groups.keys : groups).map(&:to_s)
+    end
+  end
+end

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -6,7 +6,7 @@ module DemoMode
   class Persona
     include ActiveModel::Model
 
-    attr_accessor :name, :file_checksum
+    attr_accessor :name, :file_checksum, :file_path
 
     validates :name, presence: true
     validate :persona_must_have_at_least_one_feature
@@ -15,7 +15,7 @@ module DemoMode
       if name
         @group = name
       else
-        @group
+        @group || folder_group
       end
     end
 
@@ -148,6 +148,15 @@ module DemoMode
     end
 
     private
+
+    def folder_group
+      return unless DemoMode.group_by_folder?
+      return unless file_path
+
+      relative = Pathname.new(file_path).relative_path_from(Rails.root.join(DemoMode.personas_path))
+      folder = relative.dirname.to_s
+      folder unless folder == '.'
+    end
 
     def persona_must_have_at_least_one_feature
       errors.add(:base, <<~ERR) unless features.count >= 1

--- a/lib/demo_mode/persona.rb
+++ b/lib/demo_mode/persona.rb
@@ -11,6 +11,14 @@ module DemoMode
     validates :name, presence: true
     validate :persona_must_have_at_least_one_feature
 
+    def group(name = nil)
+      if name
+        @group = name
+      else
+        @group
+      end
+    end
+
     def icon(name_or_path = nil, &block)
       if block
         @icon = block

--- a/lib/demo_mode/version.rb
+++ b/lib/demo_mode/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DemoMode
-  VERSION = '3.10.0'
+  VERSION = '3.11.0'
 end

--- a/public/demo_mode/assets/demo_mode.css
+++ b/public/demo_mode/assets/demo_mode.css
@@ -320,3 +320,13 @@ td {
 .hidden {
     display: none;
 }
+
+.persona-group {
+    margin-top: 1rem;
+}
+
+.persona-group summary {
+    cursor: pointer;
+    font-weight: bold;
+    padding: 0.5rem 0;
+}

--- a/public/demo_mode/assets/demo_mode.js
+++ b/public/demo_mode/assets/demo_mode.js
@@ -55,14 +55,25 @@
     }
 
     function updateTable() {
-      var table = document.querySelector(`.${input.dataset.table}`);
-      if (table) {
+      var tables = document.querySelectorAll(`.${input.dataset.table}`);
+      if (tables.length === 0) {
+        alert("TableFilter cannot find its table");
+        return;
+      }
+      Array.prototype.forEach.call(tables, function (table) {
         Array.prototype.forEach.call(table.tBodies, function (tbody) {
           Array.prototype.forEach.call(tbody.rows, filter);
         });
-      } else {
-        alert("TableFilter cannot find its table");
-      }
+      });
+      revealGroupsWithMatches();
+    }
+
+    function revealGroupsWithMatches() {
+      var groups = document.querySelectorAll("details.persona-group");
+      Array.prototype.forEach.call(groups, function (group) {
+        var hasMatch = !!group.querySelector("tbody tr[data-matches]");
+        group.open = inputValue !== "" && hasMatch;
+      });
     }
 
     function updateHistory() {
@@ -75,8 +86,13 @@
 
     function filter(row) {
       var text = row.textContent.toLowerCase().replace(/[^0-9a-zA-Z ]/g, "");
-      row.style.display =
-        text.indexOf(inputValue) === -1 ? "none" : "table-row";
+      var matches = text.indexOf(inputValue) !== -1;
+      row.style.display = matches ? "table-row" : "none";
+      if (matches) {
+        row.setAttribute("data-matches", "");
+      } else {
+        row.removeAttribute("data-matches");
+      }
     }
 
     function debounce(func, threshold) {

--- a/spec/demo_mode/grouper_spec.rb
+++ b/spec/demo_mode/grouper_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'demo_mode/grouper'
+
+RSpec.describe DemoMode::Grouper do
+  def grouper(personas, groups: [])
+    described_class.new(personas, groups: groups)
+  end
+
+  def fake_persona(name, group)
+    Struct.new(:name, :group).new(name, group)
+  end
+
+  describe '#named' do
+    it 'buckets personas by group name, excluding ungrouped personas' do
+      first_playwright = fake_persona('first_playwright', 'Playwright tests')
+      second_playwright = fake_persona('second_playwright', 'Playwright tests')
+      plain_persona = fake_persona('plain_persona', nil)
+
+      named = grouper([first_playwright, second_playwright, plain_persona]).named
+
+      expect(named.to_h).to eq('Playwright tests' => [first_playwright, second_playwright])
+    end
+
+    it 'defaults to alphabetical order when no groups config is set' do
+      zebra = fake_persona('z_persona', 'zebra')
+      aardvark = fake_persona('a_persona', 'aardvark')
+
+      named = grouper([zebra, aardvark]).named
+
+      expect(named.map(&:first)).to eq %w(aardvark zebra)
+    end
+
+    it 'orders named groups per the groups config, with unlisted groups falling back to alphabetical' do
+      aardvark = fake_persona('a_persona', 'aardvark')
+      zebra = fake_persona('z_persona', 'zebra')
+      middle = fake_persona('m_persona', 'middle')
+
+      named = grouper([aardvark, zebra, middle], groups: %w(zebra aardvark)).named
+
+      expect(named.map(&:first)).to eq %w(zebra aardvark middle)
+    end
+
+    it 'orders named groups per a groups hash, keyed by the raw group name' do
+      aardvark = fake_persona('a_persona', 'aardvark')
+      zebra = fake_persona('z_persona', 'zebra')
+
+      named = grouper([aardvark, zebra], groups: { 'zebra' => 'The Zebras' }).named
+
+      expect(named.map(&:first)).to eq %w(zebra aardvark)
+    end
+  end
+
+  describe '#named_groups' do
+    it 'pairs each group with its resolved name and personas, in order' do
+      aardvark = fake_persona('a_persona', 'aardvark')
+      zebra = fake_persona('z_persona', 'zebra')
+
+      named_groups = grouper([aardvark, zebra], groups: { 'zebra' => 'The Zebras' }).named_groups
+
+      expect(named_groups).to eq [
+        ['The Zebras', [zebra]],
+        ['aardvark', [aardvark]],
+      ]
+    end
+  end
+
+  describe '#ungrouped' do
+    it 'returns personas with no group' do
+      plain_persona = fake_persona('plain_persona', nil)
+      grouped_persona = fake_persona('grouped_persona', 'Playwright tests')
+
+      expect(grouper([plain_persona, grouped_persona]).ungrouped).to eq [plain_persona]
+    end
+
+    it 'returns an empty array when every persona is grouped' do
+      grouped_persona = fake_persona('grouped_persona', 'Playwright tests')
+
+      expect(grouper([grouped_persona]).ungrouped).to eq []
+    end
+  end
+
+  describe '#name_for' do
+    it 'defaults to the raw group key when groups is an array' do
+      expect(grouper([], groups: %w(retail)).name_for('retail')).to eq 'retail'
+    end
+
+    it 'uses the configured label when groups is a hash' do
+      expect(grouper([], groups: { 'retail' => 'Retail Banking' }).name_for('retail')).to eq 'Retail Banking'
+    end
+
+    it 'falls back to the raw key for groups not present in the hash' do
+      expect(grouper([], groups: { 'retail' => 'Retail Banking' }).name_for('wealth')).to eq 'wealth'
+    end
+  end
+end

--- a/spec/demo_mode_spec.rb
+++ b/spec/demo_mode_spec.rb
@@ -410,47 +410,27 @@ RSpec.describe DemoMode do
       end
     end
 
-    describe '.grouped_personas' do
-      it 'buckets personas by group name, ungrouped under nil' do
-        described_class.add_persona('first_playwright') do
-          group 'Playwright tests'
-          features << 'foo'
-          sign_in_as { 'banana' }
-        end
-        described_class.add_persona('second_playwright') do
-          group 'Playwright tests'
-          features << 'bar'
-          sign_in_as { 'apple' }
-        end
-        described_class.add_persona('plain_persona') do
-          features << 'baz'
-          sign_in_as { 'cherry' }
-        end
-
-        grouped = described_class.grouped_personas.transform_values { |personas| personas.map { |p| p.name.to_s } }
-
-        expect(grouped).to eq(
-          'Playwright tests' => %w(first_playwright second_playwright),
-          nil => %w(plain_persona),
-        )
-      end
-
-      it 'excludes callout personas' do
+    describe '.grouper' do
+      it 'builds a Grouper from standard personas, excluding callouts' do
         described_class.add_persona('a_callout') do
-          group 'Playwright tests'
           callout true
           features << 'foo'
           sign_in_as { 'banana' }
         end
         described_class.add_persona('a_standard') do
-          group 'Playwright tests'
           features << 'bar'
           sign_in_as { 'apple' }
         end
 
-        grouped = described_class.grouped_personas
+        expect(described_class.grouper.ungrouped.map { |p| p.name.to_s }).to eq %w(a_standard)
+      end
 
-        expect(grouped.fetch('Playwright tests').map { |p| p.name.to_s }).to eq %w(a_standard)
+      it "passes the configured groups through to the Grouper's name_for" do
+        described_class.configure do
+          groups('some_group' => 'Some Group')
+        end
+
+        expect(described_class.grouper.name_for('some_group')).to eq 'Some Group'
       end
     end
   end

--- a/spec/demo_mode_spec.rb
+++ b/spec/demo_mode_spec.rb
@@ -367,6 +367,49 @@ RSpec.describe DemoMode do
       end
     end
 
+    describe 'folder-derived groups' do
+      before do
+        described_class.configure do
+          personas_path 'config/grouped-personas'
+        end
+      end
+
+      context 'when group_by_folder is disabled' do
+        it 'does not derive a group from the folder' do
+          persona = described_class.personas.find { |p| p.name.to_s == 'retail: alice' }
+          expect(persona.group).to be_nil
+        end
+      end
+
+      context 'when group_by_folder is enabled' do
+        before do
+          described_class.configure do
+            group_by_folder true
+          end
+        end
+
+        it 'derives a one-level group from the folder' do
+          persona = described_class.personas.find { |p| p.name.to_s == 'retail: alice' }
+          expect(persona.group).to eq 'retail'
+        end
+
+        it 'compacts nested folders into a single top-level label' do
+          persona = described_class.personas.find { |p| p.name.to_s == 'retail: team1 — carol' }
+          expect(persona.group).to eq 'retail/team1'
+        end
+
+        it 'leaves a root-level persona ungrouped' do
+          persona = described_class.personas.find { |p| p.name.to_s == 'dave' }
+          expect(persona.group).to be_nil
+        end
+
+        it 'lets an explicit group override the folder-derived group' do
+          persona = described_class.personas.find { |p| p.name.to_s == 'wealth: erin' }
+          expect(persona.group).to eq 'Explicit group'
+        end
+      end
+    end
+
     describe '.grouped_personas' do
       it 'buckets personas by group name, ungrouped under nil' do
         described_class.add_persona('first_playwright') do
@@ -384,11 +427,12 @@ RSpec.describe DemoMode do
           sign_in_as { 'cherry' }
         end
 
-        grouped = described_class.grouped_personas
+        grouped = described_class.grouped_personas.transform_values { |personas| personas.map { |p| p.name.to_s } }
 
-        expect(grouped.fetch('Playwright tests').map { |p| p.name.to_s })
-          .to eq %w(first_playwright second_playwright)
-        expect(grouped.fetch(nil).map { |p| p.name.to_s }).to eq %w(plain_persona)
+        expect(grouped).to eq(
+          'Playwright tests' => %w(first_playwright second_playwright),
+          nil => %w(plain_persona),
+        )
       end
 
       it 'excludes callout personas' do

--- a/spec/demo_mode_spec.rb
+++ b/spec/demo_mode_spec.rb
@@ -342,6 +342,75 @@ RSpec.describe DemoMode do
       expect(value).to eq('banana-foo')
     end
   end
+
+  describe 'persona grouping' do
+    describe 'Persona#group' do
+      it 'defaults to nil when no group is set' do
+        described_class.add_persona('ungrouped_persona') do
+          features << 'foo'
+          sign_in_as { 'banana' }
+        end
+
+        persona = described_class.personas.find { |p| p.name.to_s == 'ungrouped_persona' }
+        expect(persona.group).to be_nil
+      end
+
+      it 'returns the explicitly set group name' do
+        described_class.add_persona('grouped_persona') do
+          group 'Playwright tests'
+          features << 'foo'
+          sign_in_as { 'banana' }
+        end
+
+        persona = described_class.personas.find { |p| p.name.to_s == 'grouped_persona' }
+        expect(persona.group).to eq 'Playwright tests'
+      end
+    end
+
+    describe '.grouped_personas' do
+      it 'buckets personas by group name, ungrouped under nil' do
+        described_class.add_persona('first_playwright') do
+          group 'Playwright tests'
+          features << 'foo'
+          sign_in_as { 'banana' }
+        end
+        described_class.add_persona('second_playwright') do
+          group 'Playwright tests'
+          features << 'bar'
+          sign_in_as { 'apple' }
+        end
+        described_class.add_persona('plain_persona') do
+          features << 'baz'
+          sign_in_as { 'cherry' }
+        end
+
+        grouped = described_class.grouped_personas
+
+        expect(grouped.fetch('Playwright tests').map { |p| p.name.to_s })
+          .to eq %w(first_playwright second_playwright)
+        expect(grouped.fetch(nil).map { |p| p.name.to_s }).to eq %w(plain_persona)
+      end
+
+      it 'excludes callout personas' do
+        described_class.add_persona('a_callout') do
+          group 'Playwright tests'
+          callout true
+          features << 'foo'
+          sign_in_as { 'banana' }
+        end
+        described_class.add_persona('a_standard') do
+          group 'Playwright tests'
+          features << 'bar'
+          sign_in_as { 'apple' }
+        end
+
+        grouped = described_class.grouped_personas
+
+        expect(grouped.fetch('Playwright tests').map { |p| p.name.to_s }).to eq %w(a_standard)
+      end
+    end
+  end
+
   describe '.session_url' do
     let(:session) { DemoMode::Session.new(id: 2) }
     let(:demo_mode_options) { {} }

--- a/spec/dummy/config/grouped-personas/dave.rb
+++ b/spec/dummy/config/grouped-personas/dave.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+DemoMode.add_persona do
+  features << 'foo'
+  sign_in_as { DummyUser.create!(name: 'Dave') }
+end

--- a/spec/dummy/config/grouped-personas/retail/alice.rb
+++ b/spec/dummy/config/grouped-personas/retail/alice.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+DemoMode.add_persona do
+  features << 'foo'
+  sign_in_as { DummyUser.create!(name: 'Alice') }
+end

--- a/spec/dummy/config/grouped-personas/retail/team1/carol.rb
+++ b/spec/dummy/config/grouped-personas/retail/team1/carol.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+DemoMode.add_persona do
+  features << 'foo'
+  sign_in_as { DummyUser.create!(name: 'Carol') }
+end

--- a/spec/dummy/config/grouped-personas/wealth/erin.rb
+++ b/spec/dummy/config/grouped-personas/wealth/erin.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+DemoMode.add_persona do
+  group 'Explicit group'
+  features << 'foo'
+  sign_in_as { DummyUser.create!(name: 'Erin') }
+end

--- a/spec/system/demo_splash_spec.rb
+++ b/spec/system/demo_splash_spec.rb
@@ -186,6 +186,62 @@ describe 'Demo Splash' do
       end
     end
 
+    context 'with grouped personas' do
+      before do
+        DemoMode.add_persona :an_ungrouped_persona do
+          features << 'Cool feature'
+          sign_in_as { DummyUser.create!(name: 'An Ungrouped Persona') }
+        end
+        DemoMode.add_persona :a_grouped_persona do
+          group 'Playwright tests'
+          features << 'Test feature'
+          sign_in_as { DummyUser.create!(name: 'A Grouped Persona') }
+        end
+      end
+
+      it 'renders grouped personas in a collapsed section with a count' do
+        visit '/'
+
+        expect(page).to have_text('An Ungrouped Persona')
+        expect(page).to have_text('Playwright tests')
+        expect(page).to have_text('Playwright tests (1)')
+
+        # collapsed: the grouped persona is hidden until the section is expanded
+        expect(page).to have_no_text('A Grouped Persona')
+
+        find('summary', text: 'Playwright tests').click
+        expect(page).to have_text('A Grouped Persona')
+      end
+
+      it 'filters across every group and opens a group when a search matches a hidden row' do
+        visit '/'
+
+        expect(page).to have_no_text('A Grouped Persona')
+
+        fill_in 'Search...', with: 'A Grouped Persona'
+
+        expect(page).to have_text('A Grouped Persona')
+        expect(page).to have_no_text('An Ungrouped Persona')
+
+        fill_in 'Search...', with: 'An Ungrouped Persona'
+
+        expect(page).to have_text('An Ungrouped Persona')
+        expect(page).to have_no_text('A Grouped Persona')
+      end
+
+      it 'signs in with a grouped persona' do
+        visit '/'
+
+        find('summary', text: 'Playwright tests').click
+
+        within '.dm-Persona--aGroupedPersona' do
+          click_button 'Sign In'
+        end
+
+        expect(page).to have_text('Your Name: A Grouped Persona')
+      end
+    end
+
     context 'when a persona uses a custom sign in method' do
       before do
         DemoMode.add_persona :redirects_to_not_found do

--- a/spec/system/demo_splash_spec.rb
+++ b/spec/system/demo_splash_spec.rb
@@ -240,6 +240,34 @@ describe 'Demo Splash' do
 
         expect(page).to have_text('Your Name: A Grouped Persona')
       end
+
+      it 'renders ungrouped personas before groups by default' do
+        visit '/'
+
+        sections = page.all('article section, article details').map(&:text)
+        ungrouped_index = sections.index { |text| text.include?('An Ungrouped Persona') }
+        group_index = sections.index { |text| text.include?('Playwright tests') }
+
+        expect(ungrouped_index).to be < group_index
+      end
+
+      context 'when ungrouped_first is disabled' do
+        before do
+          DemoMode.configure do
+            ungrouped_first false
+          end
+        end
+
+        it 'renders groups before ungrouped personas' do
+          visit '/'
+
+          sections = page.all('article section, article details').map(&:text)
+          ungrouped_index = sections.index { |text| text.include?('An Ungrouped Persona') }
+          group_index = sections.index { |text| text.include?('Playwright tests') }
+
+          expect(group_index).to be < ungrouped_index
+        end
+      end
     end
 
     context 'when a persona uses a custom sign in method' do

--- a/spec/system/demo_splash_spec.rb
+++ b/spec/system/demo_splash_spec.rb
@@ -240,34 +240,6 @@ describe 'Demo Splash' do
 
         expect(page).to have_text('Your Name: A Grouped Persona')
       end
-
-      it 'renders ungrouped personas before groups by default' do
-        visit '/'
-
-        sections = page.all('article section, article details').map(&:text)
-        ungrouped_index = sections.index { |text| text.include?('An Ungrouped Persona') }
-        group_index = sections.index { |text| text.include?('Playwright tests') }
-
-        expect(ungrouped_index).to be < group_index
-      end
-
-      context 'when ungrouped_first is disabled' do
-        before do
-          DemoMode.configure do
-            ungrouped_first false
-          end
-        end
-
-        it 'renders groups before ungrouped personas' do
-          visit '/'
-
-          sections = page.all('article section, article details').map(&:text)
-          ungrouped_index = sections.index { |text| text.include?('An Ungrouped Persona') }
-          group_index = sections.index { |text| text.include?('Playwright tests') }
-
-          expect(group_index).to be < ungrouped_index
-        end
-      end
     end
 
     context 'when a persona uses a custom sign in method' do


### PR DESCRIPTION
Adds an opt-in way to bucket personas into collapsed `<details>` sections on the persona list, instead of one flat table. Fully backward compatible: an app that changes nothing sees no change.

Two ways to assign a group, either or both:
  - `group 'Name'`, set explicitly on a persona
  - `DemoMode.group_by_folder true`, which derives each persona's group from its folder path 

Two ways to change group ordering, either or both:
  - `DemoMode.ungrouped_first false`, moves ungrouped personas below the groups
  - `DemoMode.groups(folder: 'Display Name')`, override the label shown for a group

Decisions:
-  An explicit group wins over a folder-derived one.
-  Folders nested more than one level deep compact into a single top-level group rather than nesting `<details>`.
-  Search still filters across every group, and auto-opens a group when a term matches a row inside it.